### PR TITLE
Disable looping of ADX tracks played from memory

### DIFF
--- a/src/port/sdl/sdl_adx_sound.c
+++ b/src/port/sdl/sdl_adx_sound.c
@@ -421,7 +421,7 @@ void SDLADXSound_StartMem(void* buf, size_t size) {
     SDLADXSound_Stop();
 
     ADXTrack* track = alloc_track();
-    track_init(track, -1, buf, size, true);
+    track_init(track, -1, buf, size, false);
 }
 
 int SDLADXSound_GetNumFiles() {


### PR DESCRIPTION
For some reason arcade version of the VS track has looping enabled in the ADX header. This can't be right, because the start/end loop indices are messed up. 

I disabled loop playback for all tracks played from memory, which fixes issues with playback of this and similar files.