### PR TITLE
Update default keyboard bindings

### DIFF
--- a/src/port/sdl/sdl_pad.c
+++ b/src/port/sdl/sdl_pad.c
@@ -224,7 +224,7 @@ void SDLPad_HandleKeyboardEvent(SDL_KeyboardEvent* event) {
         state->west = event->down;
         break;
 
-    case SDLK_SEMICOLON:
+    case SDLK_P:
         state->left_shoulder = event->down;
         break;
 
@@ -232,7 +232,7 @@ void SDLPad_HandleKeyboardEvent(SDL_KeyboardEvent* event) {
         state->right_shoulder = event->down;
         break;
 
-    case SDLK_P:
+    case SDLK_SEMICOLON:
         state->left_trigger = event->down ? SDL_MAX_SINT16 : 0;
         break;
 


### PR DESCRIPTION
This updates the default keyboard bindings as follows:

LP -> U
MP -> I
HP -> O

LK -> J
MK -> K
HK -> L

(Unused, follows arcade stick layout)
~L1 -> ;
L2 -> P~
L1 -> P
L2 -> ;

(Unused, just placed somewhere close)
L3 -> 9
R3 -> 0

Movement stays the same.