### PR TITLE
[macOS] Add app category to `Info.plist`

### DIFF
--- a/cmake/Info.plist
+++ b/cmake/Info.plist
@@ -16,5 +16,7 @@
     <string>????</string>
     <key>LSMinimumSystemVersion</key> 
     <string>11.0</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
 </dict>
 </plist>


### PR DESCRIPTION
Setting the app category to games in the Info.plist file allows for the game to run with Game Mode automatically enabled when in fullscreen on macOS.

https://support.apple.com/en-us/105118
https://eclecticlight.co/2023/11/16/game-mode-revisited-why-e-cores-are-so-important/