### PR TITLE
Fix async IO

### DIFF
--- a/src/port/io/afs.h
+++ b/src/port/io/afs.h
@@ -22,6 +22,7 @@ unsigned int AFS_GetSize(int file_num);
 void AFS_RunServer();
 AFSHandle AFS_Open(int file_num);
 void AFS_Read(AFSHandle handle, int sectors, void* buf);
+void AFS_ReadSync(AFSHandle handle, int sectors, void* buf);
 void AFS_Stop(AFSHandle handle);
 void AFS_Close(AFSHandle handle);
 AFSReadState AFS_GetState(AFSHandle handle);

--- a/src/sf33rd/Source/Game/GD3rd.c
+++ b/src/sf33rd/Source/Game/GD3rd.c
@@ -122,25 +122,9 @@ s32 fsCheckFileReaded(REQ* /* unused */) {
 }
 
 s32 fsFileReadSync(REQ* req, u32 sec, void* buff) {
-    s32 rnum = fsRequestFileRead(req, sec, buff);
-
-    if (rnum == 0) {
-        return 0;
-    }
-
-    while (1) {
-        rnum = fsCheckFileReaded(req);
-
-        if (rnum == 1) {
-            return 1;
-        }
-
-        if (rnum == 2) {
-            return 0;
-        }
-
-        waitVsyncDummy();
-    }
+    AFS_ReadSync(afs_handle, sec, buff);
+    const s32 rnum = fsCheckFileReaded(req);
+    return (rnum == 1) ? 1 : 0;
 }
 
 void waitVsyncDummy() {


### PR DESCRIPTION
At startup loading of some files overlapped with loading of ADX tracks, which lead to crashes. To fix this I implemented synchronous loading (`AFS_ReadSync`) and removed ADX's dependency on GD3rd (mostly)