### PR TITLE
Fix garbage collection of SFX voices.

### DIFF
--- a/include/port/sound/spu.h
+++ b/include/port/sound/spu.h
@@ -18,7 +18,7 @@ void SPU_Tick(s16* output);
 void SPU_VoiceStart(int vnum, u32 start_addr);
 void SPU_VoiceGetConf(int vnum, struct SPUVConf* conf);
 void SPU_VoiceSetConf(int vnum, struct SPUVConf* conf);
-int SPU_VoiceGetEnvLvl(int vnum);
+bool SPU_VoiceIsFinished(int vnum);
 void SPU_VoiceKeyOff(int vnum);
 void SPU_VoiceStop(int vnum);
 

--- a/src/port/sound/emlShim.c
+++ b/src/port/sound/emlShim.c
@@ -223,7 +223,7 @@ static int gcVoices() {
     SDL_LockMutex(soundLock);
 
     list_for_each_safe (i, n, &active_voices, list) {
-        if (SPU_VoiceGetEnvLvl(i->voice_num) == 0) {
+        if (SPU_VoiceIsFinished(i->voice_num)) {
             list_remove(&i->list);
             list_insert(&free_voices, &i->list);
             numFreed++;

--- a/src/port/sound/spu.c
+++ b/src/port/sound/spu.c
@@ -248,8 +248,12 @@ static void SPU_VoiceTick(struct SPU_Voice* v, s32* output) {
     SPU_VoiceRunADSR(v);
 }
 
-int SPU_VoiceGetEnvLvl(int vnum) {
-    return voices[vnum].envx;
+bool SPU_VoiceIsFinished(int vnum) {
+    if (voices[vnum].envx == 0 && voices[vnum].adsr_phase != ADSR_PHASE_ATTACK) {
+        return true;
+    }
+
+    return false;
 }
 
 void SPU_VoiceKeyOff(int vnum) {


### PR DESCRIPTION
We could accidentally think a voice was done even if it had just started if we read ENVX before an SPU tick.