### PR TITLE
Add PDB creation for Windows debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,10 @@ elseif(WIN32)
         ${SDL3_ROOT}/lib/libSDL3.dll.a
 		dbghelp
     )
+    target_link_options(3sx PRIVATE
+        --for-linker
+        --pdb=3sx.pdb
+    )
 elseif(UNIX)
     target_link_libraries(3sx PRIVATE
         ${FFMPEG_ROOT}/lib/libavcodec.so
@@ -177,6 +181,11 @@ elseif(WIN32)
 		POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
 		DESTINATION bin
 	)
+
+    install(FILES
+        "build/3sx.pdb"
+        DESTINATION bin
+    )
 elseif(UNIX)
     install(TARGETS 3sx
         RUNTIME DESTINATION bin


### PR DESCRIPTION
Added provisions in the CMakeList to create and copy a PDB (debug information file) to the installed location.

Even in release mode, this allows Windows builds to be debugged or print stack traces with correct symbol names.