### PR TITLE
Allow connecting to custom IPs in netplay

### DIFF
--- a/src/netplay/netplay.c
+++ b/src/netplay/netplay.c
@@ -54,6 +54,7 @@ typedef struct State {
 static GekkoSession* session = NULL;
 static unsigned short local_port = 0;
 static unsigned short remote_port = 0;
+static const char* remote_ip = NULL;
 static int player_number = 0;
 static int player_handle = 0;
 static SessionState session_state = SESSION_IDLE;
@@ -148,7 +149,7 @@ static void configure_gekko() {
     printf("starting a session for player %d at port %hu\n", player_number, local_port);
 
     char remote_address_str[100];
-    SDL_snprintf(remote_address_str, sizeof(remote_address_str), "127.0.0.1:%hu", remote_port);
+    SDL_snprintf(remote_address_str, sizeof(remote_address_str), "%s:%hu", remote_ip, remote_port);
     GekkoNetAddress remote_address = { .data = remote_address_str, .size = strlen(remote_address_str) };
 
     if (player_number == 0) {
@@ -494,15 +495,26 @@ static void run_netplay() {
     }
 }
 
-void Netplay_SetPlayer(int player) {
-    if (player == 1) {
-        local_port = 50000;
-        remote_port = 50001;
-        player_number = 0;
+void Netplay_SetParams(int player, const char* ip) {
+    SDL_assert(player == 1 || player == 2);
+    player_number = player - 1;
+    remote_ip = ip;
+
+    if (SDL_strcmp(ip, "127.0.0.1") == 0) {
+        switch (player_number) {
+        case 0:
+            local_port = 50000;
+            remote_port = 50001;
+            break;
+
+        case 1:
+            local_port = 50001;
+            remote_port = 50000;
+            break;
+        }
     } else {
-        local_port = 50001;
+        local_port = 50000;
         remote_port = 50000;
-        player_number = 1;
     }
 }
 

--- a/src/netplay/netplay.h
+++ b/src/netplay/netplay.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-void Netplay_SetPlayer(int player);
+void Netplay_SetParams(int player, const char* ip);
 void Netplay_Begin();
 void Netplay_Run();
 

--- a/src/sf33rd/Source/Game/main.c
+++ b/src/sf33rd/Source/Game/main.c
@@ -139,15 +139,11 @@ int main(int argc, char* argv[]) {
     init_windows_console();
     SDLApp_Init();
 
-    int player = 0;
-
-    if (argc > 1) {
-        player = SDL_atoi(argv[1]);
-    } else {
-        player = 1;
+    if (argc >= 3) {
+        const int player = SDL_atoi(argv[1]);
+        const char* ip = argv[2];
+        Netplay_SetParams(player, ip);
     }
-
-    Netplay_SetPlayer(player);
 
     while (is_running) {
         is_running = SDLApp_PollEvents();


### PR DESCRIPTION
This allows setting a custom remote IP address to connect to during netplay. You can now connect two peers on local network.

If player 2's IP is 192.168.0.144 then player 1 should run:
```bash
./build/3sx 1 192.168.0.144
```

With port forwarding remote play should be possible too.