### PR TITLE
fix desync on session start

### DIFF
--- a/src/netplay/netplay.c
+++ b/src/netplay/netplay.c
@@ -125,6 +125,8 @@ static void setup_vs_mode() {
     cpExitTask(TASK_MENU);
 
     E_Timer = 0; // E_Timer can have different values depending on when the session was initiated
+    G_Timer = 0; // G_Timer accumulates during the title screen and differs between clients on first connection
+    bg_w.bgw[0].l_limit = 0; // l_limit an animation counter used in the opening sequence, can differ between clients
 
     Deley_Shot_No[0] = 0;
     Deley_Shot_No[1] = 0;


### PR DESCRIPTION
```
0: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
0: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
1: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
1: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
2: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
2: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
3: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
3: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
4: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
4: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
5: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
5: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
6: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
6: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
7: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
7: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
8: mismatch at byte 0x5F6 (0x35 vs 0x69). Path: gs.G_Timer
8: mismatch at byte 0x3588 (0x0 vs 0x6). Path: gs.bg_w.bgw[0].l_limit
```

i found the desync at session start i had
setting both G_Timer and bg_w.bgw[0].l_limit to zero in the setup_vs_mode fucntion seems to fix it.
G_Timer seems to accumulates during the title screen and differs between clients on first connection
and  l_limit seems to be an animation counter?  they dont seem to affect gameplay tho