### PR TITLE
Load game data from executable directory and persist button remappings

### DIFF
--- a/include/port/button_config.h
+++ b/include/port/button_config.h
@@ -1,0 +1,12 @@
+#ifndef PORT_BUTTON_CONFIG_H
+#define PORT_BUTTON_CONFIG_H
+
+/// Load button mappings from buttons.ini (next to the executable).
+/// Should be called after Setup_Default_Game_Option() so save_w is initialized.
+void ButtonConfig_Load();
+
+/// Save current button mappings to buttons.ini (next to the executable).
+/// Should be called whenever Save_Game_Data() runs.
+void ButtonConfig_Save();
+
+#endif

--- a/src/port/button_config.c
+++ b/src/port/button_config.c
@@ -1,0 +1,141 @@
+#include "port/button_config.h"
+#include "port/paths.h"
+#include "structs.h"
+
+#include <SDL3/SDL.h>
+#include <stdio.h>
+#include <string.h>
+
+extern struct _SAVE_W save_w[6];
+
+static const char* BUTTON_NAMES[8] = {
+    "Square", "Triangle", "R1", "L1", "Cross", "Circle", "R2", "L2"
+};
+
+static const char* ACTION_NAMES[12] = {
+    "LP", "MP", "HP", "LK", "MK", "HK",
+    "6", "7", "8", "9", "10", "None"
+};
+
+static const char* INI_FILENAME = "buttons.ini";
+
+static char* get_ini_path() {
+    const char* base = Paths_GetBasePath();
+    char* path = NULL;
+    SDL_asprintf(&path, "%s%s", base, INI_FILENAME);
+    return path;
+}
+
+static const char* action_name(u8 value) {
+    if (value < 12) {
+        return ACTION_NAMES[value];
+    }
+    return "None";
+}
+
+static u8 action_value(const char* name) {
+    for (int i = 0; i < 12; i++) {
+        if (SDL_strcasecmp(name, ACTION_NAMES[i]) == 0) {
+            return (u8)i;
+        }
+    }
+    return 11;
+}
+
+void ButtonConfig_Save() {
+    char* path = get_ini_path();
+    FILE* f = fopen(path, "w");
+    SDL_free(path);
+
+    if (f == NULL) {
+        printf("ButtonConfig: Failed to save buttons.ini\n");
+        return;
+    }
+
+    fprintf(f, "# 3SX Button Mappings\n");
+    fprintf(f, "# Actions: LP, MP, HP, LK, MK, HK, None\n");
+    fprintf(f, "# Buttons: Square, Triangle, R1, L1, Cross, Circle, R2, L2\n\n");
+
+    for (int player = 0; player < 2; player++) {
+        fprintf(f, "[Player%d]\n", player + 1);
+
+        for (int btn = 0; btn < 8; btn++) {
+            fprintf(f, "%s = %s\n", BUTTON_NAMES[btn],
+                    action_name(save_w[1].Pad_Infor[player].Shot[btn]));
+        }
+
+        fprintf(f, "Vibration = %d\n\n", save_w[1].Pad_Infor[player].Vibration);
+    }
+
+    fclose(f);
+    printf("ButtonConfig: Saved buttons.ini\n");
+}
+
+void ButtonConfig_Load() {
+    char* path = get_ini_path();
+    FILE* f = fopen(path, "r");
+    SDL_free(path);
+
+    if (f == NULL) {
+        printf("ButtonConfig: No buttons.ini found, using defaults\n");
+        return;
+    }
+
+    int current_player = -1;
+    char line[256];
+
+    while (fgets(line, sizeof(line), f)) {
+        line[strcspn(line, "\r\n")] = '\0';
+
+        char* p = line;
+        while (*p == ' ' || *p == '\t') p++;
+
+        if (*p == '\0' || *p == '#') continue;
+
+        if (*p == '[') {
+            if (SDL_strncasecmp(p, "[Player1]", 9) == 0) {
+                current_player = 0;
+            } else if (SDL_strncasecmp(p, "[Player2]", 9) == 0) {
+                current_player = 1;
+            }
+            continue;
+        }
+
+        if (current_player < 0 || current_player > 1) continue;
+
+        char key[128];
+        char value[128];
+
+        if (sscanf(p, "%127[^=]=%127s", key, value) != 2) continue;
+
+        // Trim trailing spaces from key
+        char* end = key + strlen(key) - 1;
+        while (end > key && (*end == ' ' || *end == '\t')) { *end = '\0'; end--; }
+
+        // Trim leading spaces from value
+        char* vp = value;
+        while (*vp == ' ' || *vp == '\t') vp++;
+
+        if (SDL_strcasecmp(key, "Vibration") == 0) {
+            save_w[1].Pad_Infor[current_player].Vibration = (u8)SDL_atoi(vp);
+            continue;
+        }
+
+        for (int btn = 0; btn < 8; btn++) {
+            if (SDL_strcasecmp(key, BUTTON_NAMES[btn]) == 0) {
+                save_w[1].Pad_Infor[current_player].Shot[btn] = action_value(vp);
+                break;
+            }
+        }
+    }
+
+    fclose(f);
+
+    // Propagate to other save_w slots (same as Save_Game_Data does)
+    for (int slot = 4; slot <= 5; slot++) {
+        save_w[slot].Pad_Infor[0] = save_w[1].Pad_Infor[0];
+        save_w[slot].Pad_Infor[1] = save_w[1].Pad_Infor[1];
+    }
+
+    printf("ButtonConfig: Loaded buttons.ini\n");
+}

--- a/src/port/resources.c
+++ b/src/port/resources.c
@@ -3,7 +3,6 @@
 #include "port/sdl/sdl_app.h"
 
 #include <SDL3/SDL.h>
-#include <cdio/iso9660.h>
 
 typedef enum FlowState { INIT, DIALOG_OPENED, COPY_ERROR, COPY_SUCCESS } ResourceCopyingFlowState;
 
@@ -28,72 +27,35 @@ static void create_resources_directory() {
     SDL_free(path);
 }
 
-#define CHUNK_SECTORS 16
-#define BUFFER_SIZE (ISO_BLOCKSIZE * CHUNK_SECTORS)
-
-static void open_file_dialog_callback(void* userdata, const char* const* filelist, int filter) {
-    const char* iso_path = filelist[0];
-
-    iso9660_t* iso = iso9660_open(iso_path);
-
-    if (iso == NULL) {
-        flow_state = COPY_ERROR;
-        return;
-    }
-
-    iso9660_stat_t* stat = iso9660_ifs_stat(iso, "/THIRD/SF33RD.AFS;1");
-
-    if (stat == NULL) {
-        // Try a different path
-        stat = iso9660_ifs_stat(iso, "/SF33RD.AFS;1");
-
-        if (stat == NULL) {
-            iso9660_close(iso);
-            flow_state = COPY_ERROR;
-            return;
-        }
-    }
+static bool copy_file(const char* rom_path, const char* src_name, const char* dst_name) {
+    char* src_path = NULL;
+    char* dst_path = Resources_GetPath(dst_name);
+    SDL_asprintf(&src_path, "%s/%s", rom_path, src_name);
 
     create_resources_directory();
-    char* dst_path = Resources_GetPath("SF33RD.AFS");
-    SDL_IOStream* dst_io = SDL_IOFromFile(dst_path, "w");
+    const bool success = SDL_CopyFile(src_path, dst_path);
+
+    SDL_free(src_path);
     SDL_free(dst_path);
 
-    uint8_t buffer[BUFFER_SIZE];
-    uint64_t bytes_remaining = stat->total_size;
-    lsn_t current_lsn = stat->lsn;
-
-    while (bytes_remaining > 0) {
-        const uint64_t bytes_to_read = SDL_min(sizeof(buffer), bytes_remaining);
-        const uint64_t sectors_to_read = (bytes_to_read + ISO_BLOCKSIZE - 1) / ISO_BLOCKSIZE;
-
-        const long bytes_read = iso9660_iso_seek_read(iso, buffer, current_lsn, sectors_to_read);
-        SDL_WriteIO(dst_io, buffer, bytes_read);
-
-        bytes_remaining -= bytes_read;
-        current_lsn += sectors_to_read;
-    }
-
-    iso9660_stat_free(stat);
-    iso9660_close(iso);
-    SDL_CloseIO(dst_io);
-    flow_state = COPY_SUCCESS;
+    return success;
 }
 
-static void open_dialog() {
-    flow_state = DIALOG_OPENED;
-    const SDL_DialogFileFilter filter = { .name = "Game iso", .pattern = "iso" };
-    SDL_ShowOpenFileDialog(open_file_dialog_callback, NULL, window, &filter, 1, NULL, false);
+static void open_folder_dialog_callback(void* userdata, const char* const* filelist, int filter) {
+    const char* rom_path = filelist[0];
+    bool success = true;
+    success &= copy_file(rom_path, "THIRD/SF33RD.AFS", "SF33RD.AFS");
+    flow_state = success ? COPY_SUCCESS : COPY_ERROR;
 }
 
 char* Resources_GetPath(const char* file_path) {
-    const char* base = Paths_GetPrefPath();
+    const char* base = Paths_GetBasePath();
     char* full_path = NULL;
 
     if (file_path == NULL) {
-        SDL_asprintf(&full_path, "%sresources/", base);
+        SDL_asprintf(&full_path, "%s", base);
     } else {
-        SDL_asprintf(&full_path, "%sresources/%s", base, file_path);
+        SDL_asprintf(&full_path, "%s%s", base, file_path);
     }
 
     return full_path;
@@ -110,9 +72,10 @@ bool Resources_RunResourceCopyingFlow() {
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION,
                                  "Resources are missing",
                                  "3SX needs resources from a copy of \"Street Fighter III: 3rd Strike\" to run. Choose "
-                                 "the iso in the next dialog",
+                                 "a location with the game files in the next dialog",
                                  window);
-        open_dialog();
+        flow_state = DIALOG_OPENED;
+        SDL_ShowOpenFolderDialog(open_folder_dialog_callback, NULL, window, NULL, false);
         break;
 
     case DIALOG_OPENED:
@@ -120,9 +83,12 @@ bool Resources_RunResourceCopyingFlow() {
         break;
 
     case COPY_ERROR:
-        SDL_ShowSimpleMessageBox(
-            SDL_MESSAGEBOX_ERROR, "Invalid iso", "The iso you provided doesn't contain the required files", window);
-        open_dialog();
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+                                 "Invalid directory",
+                                 "The directory you provided doesn't contain the required files",
+                                 window);
+        flow_state = DIALOG_OPENED;
+        SDL_ShowOpenFolderDialog(open_folder_dialog_callback, NULL, window, NULL, false);
         break;
 
     case COPY_SUCCESS:

--- a/src/sf33rd/Source/Game/system/sys_sub.c
+++ b/src/sf33rd/Source/Game/system/sys_sub.c
@@ -34,6 +34,7 @@
 #include "sf33rd/Source/Game/system/sysdir.h"
 #include "sf33rd/Source/Game/system/work_sys.h"
 #include "sf33rd/Source/Game/ui/sc_sub.h"
+#include "port/button_config.h"
 #include <memory.h>
 
 u8 Candidate_Buff[16];
@@ -547,6 +548,7 @@ void Game_Data_Init() {
         }
     }
 
+    ButtonConfig_Load();
     Ranking_Init();
     Copy_Save_w();
 }
@@ -601,6 +603,8 @@ void Save_Game_Data() {
     save_w[1].BGM_Level = Convert_Buff[3][1][1];
     save_w[1].SE_Level = Convert_Buff[3][1][2];
     save_w[1].BgmType = Convert_Buff[3][1][3];
+
+    ButtonConfig_Save();
 }
 
 void Copy_Save_w() {


### PR DESCRIPTION
- Modified Resources_GetPath() to use Paths_GetBasePath() instead of Paths_GetPrefPath(), so SF33RD.AFS is read from the same directory as the executable

- Added button_config.c/h: saves and loads button remappings to/from a buttons.ini file next to the executable

- Hooked ButtonConfig_Load() into Game_Data_Init() and ButtonConfig_Save() into Save_Game_Data() in sys_sub.c