### PR TITLE
Revert Unit_Of_Timer back to 50

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -1,0 +1,6 @@
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#define UNIT_OF_TIMER_MAX 50
+
+#endif

--- a/src/sf33rd/Source/Game/effect/effd8.c
+++ b/src/sf33rd/Source/Game/effect/effd8.c
@@ -6,6 +6,7 @@
 #include "sf33rd/Source/Game/effect/effd8.h"
 #include "bin2obj/char_table.h"
 #include "common.h"
+#include "constants.h"
 #include "sf33rd/Source/Game/effect/effect.h"
 #include "sf33rd/Source/Game/engine/charset.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
@@ -91,7 +92,7 @@ void effect_D8_move(WORK_Other* ewk) {
                 Select_Timer = 0x20;
             }
 
-            Unit_Of_Timer = 60;
+            Unit_Of_Timer = UNIT_OF_TIMER_MAX;
             ewk->wu.char_index += 1;
             set_char_move_init(&ewk->wu, 0, ewk->wu.char_index);
         }

--- a/src/sf33rd/Source/Game/screen/entry.c
+++ b/src/sf33rd/Source/Game/screen/entry.c
@@ -5,6 +5,7 @@
 
 #include "sf33rd/Source/Game/screen/entry.h"
 #include "common.h"
+#include "constants.h"
 #include "main.h"
 #include "sf33rd/AcrSDK/common/pad.h"
 #include "sf33rd/Source/Game/debug/Debug.h"
@@ -1355,7 +1356,7 @@ void Break_Into_02(s16 /* unused */) {
     }
 
     Select_Timer = 0x30;
-    Unit_Of_Timer = 60;
+    Unit_Of_Timer = UNIT_OF_TIMER_MAX;
 }
 
 void Break_Into_04(s16 /* unused */) {

--- a/src/sf33rd/Source/Game/screen/next_cpu.c
+++ b/src/sf33rd/Source/Game/screen/next_cpu.c
@@ -5,6 +5,7 @@
 
 #include "sf33rd/Source/Game/screen/next_cpu.h"
 #include "common.h"
+#include "constants.h"
 #include "sf33rd/AcrSDK/common/pad.h"
 #include "sf33rd/Source/Game/com/com_data.h"
 #include "sf33rd/Source/Game/debug/Debug.h"
@@ -140,7 +141,7 @@ void Next_CPU_1st() {
     }
 
     Time_Stop = 1;
-    Unit_Of_Timer = 60;
+    Unit_Of_Timer = UNIT_OF_TIMER_MAX;
     SelectTimer_Init();
     Rnd = random_16() & 3;
     effect_58_init(6, 10, EM_Select_Voice_Data[Rnd]);

--- a/src/sf33rd/Source/Game/screen/sel_pl.c
+++ b/src/sf33rd/Source/Game/screen/sel_pl.c
@@ -5,6 +5,7 @@
 
 #include "sf33rd/Source/Game/screen/sel_pl.h"
 #include "common.h"
+#include "constants.h"
 #include "sf33rd/AcrSDK/common/pad.h"
 #include "sf33rd/Source/Game/com/com_data.h"
 #include "sf33rd/Source/Game/debug/Debug.h"
@@ -256,7 +257,7 @@ void Sel_PL_Cont_1st() {
         Select_Timer = 0x30;
     }
 
-    Unit_Of_Timer = 60;
+    Unit_Of_Timer = UNIT_OF_TIMER_MAX;
     Setup_Face_ID();
     Setup_1st_Play_Type();
     Setup_Face_Sub();

--- a/src/sf33rd/Source/Game/select_timer.c
+++ b/src/sf33rd/Source/Game/select_timer.c
@@ -1,4 +1,5 @@
 #include "sf33rd/Source/Game/select_timer.h"
+#include "constants.h"
 #include "sf33rd/Source/Game/debug/Debug.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
 #include "types.h"
@@ -75,7 +76,7 @@ void SelectTimer_Run() {
             break;
         }
 
-        Unit_Of_Timer = 60;
+        Unit_Of_Timer = UNIT_OF_TIMER_MAX;
         bcdext = 0;
         Select_Timer = sbcd(1, Select_Timer);
 
@@ -91,7 +92,7 @@ void SelectTimer_Run() {
 
         if (Select_Timer) {
             select_timer_state.step = 1;
-            Unit_Of_Timer = 60;
+            Unit_Of_Timer = UNIT_OF_TIMER_MAX;
         } else {
             select_timer_state.timer -= 1;
 
@@ -109,7 +110,7 @@ void SelectTimer_Run() {
 
         if (Select_Timer) {
             select_timer_state.step = 1;
-            Unit_Of_Timer = 60;
+            Unit_Of_Timer = UNIT_OF_TIMER_MAX;
         }
 
         break;


### PR DESCRIPTION
`Unit_Of_Timer` controls how many frames need to pass before the timer in character select ticks down. Originally its value was 50, but some time ago I decided to change it to 60. This PR reverts that change to honor arcade authenticity

This change was verified by reverse engineering the arcade ROM. There `Unit_Of_Timer` is set to 50