### PR TITLE
Improved hitbox rendering

### DIFF
--- a/src/sf33rd/Source/Game/rendering/aboutspr.h
+++ b/src/sf33rd/Source/Game/rendering/aboutspr.h
@@ -32,7 +32,7 @@ void Mtrans_use_trans_mode(WORK* wk, s16 bsy);
 void all_cgps_put_back(WORK* wk);
 s32 set_conn_sprite(WORK_Other_CONN* wk, s16 bsy);
 void set_judge_area_sprite(WORK_Other_JUDGE* wk, s16 bsy);
-void draw_hit_judge_line(f64 arg0, f64 arg1, f64 arg2, f64 arg3, u32 col, u32 attr);
+void draw_hit_judge_line(f32 px, f32 py, f32 sx, f32 sy, u32 col, u32 attr);
 void setup_dma_group(u16 num, u32 /* unused */);
 void setup_bonus_car_parts();
 s32 setup_GILL_Opening_Ceremony();


### PR DESCRIPTION
This PR updates the hitbox rendering logic to make them look nicer instead of the original pink blobs.

The logic got a bit more complicated because the rendering path was originally just "pick color, draw box". But now it uses a small helper-based path that draws each box as a low-alpha fill plus a separate outline, with color mapping by box group (red for hitboxes and blue for hurtboxes).

I also did a readability pass while touching this code after a quick convo with ethanol in dev chat. I canonicalized draw_hit_judge_line to f32 px/py/sx/sy, cleaned up some local names, and removed unnecessary cast churn so this path is float-native end-to-end.

<img width="474" height="431" alt="Screenshot 2026-02-28 at 12 25 00 AM" src="https://github.com/user-attachments/assets/406e85a8-5d68-48cf-92fb-76da7558e918" />
