### PR TITLE
Disable some "unused"-family warnings in Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,9 @@ target_compile_options(3sx PRIVATE
     -fno-strict-aliasing
 
     ${DISABLED_WARNINGS}
+
+    $<$<CONFIG:Debug>:-Wno-unused-function>
+    $<$<CONFIG:Debug>:-Wno-unused-variable>
 )
 
 set_target_properties(3sx PROPERTIES


### PR DESCRIPTION
Sometimes when you're debugging/writing new code you might have a function or variable that is temporarily unused. It's annoying to have the compiler error out because of that. So I'm disabling `-Wunused-function` and `-Wunused-variable` under Debug configuration