### PR TITLE
Increase 2d box limit

### DIFF
--- a/src/sf33rd/Source/Game/rendering/dc_ghost.c
+++ b/src/sf33rd/Source/Game/rendering/dc_ghost.c
@@ -16,6 +16,7 @@
 #include <string.h>
 
 #define NTH_BYTE(value, n) ((((value >> n * 8) & 0xFF) << n * 8))
+#define NJDP2D_PRIM_MAX 200
 
 typedef struct {
     Vertex v;
@@ -33,7 +34,7 @@ typedef struct {
 typedef struct {
     s16 ix1st;
     s16 total;
-    NJDP2D_PRIM prim[200];
+    NJDP2D_PRIM prim[NJDP2D_PRIM_MAX];
 } NJDP2D_W;
 
 NJDP2D_W njdp2d_w;
@@ -198,7 +199,7 @@ void njdp2d_sort(f32* pos, f32 pri, uintptr_t col, s32 flag) {
     s32 ix = njdp2d_w.total;
     s32 prev;
 
-    if (ix >= 200) {
+    if (ix >= NJDP2D_PRIM_MAX) {
         // The 2D polygon display request has exceeded the buffer\n
         flLogOut("２Ｄポリゴンの表示要求がバッファをオーバーしました\n");
         return;


### PR DESCRIPTION
Training hitbox display can spike the 2D polygon queue and we were hitting the old cap/crashing. Part of why this started happening is each hitbox now draws 5 polygons instead of 1, so queue usage goes up fast in busy scenes (like if there are extra projectiles on screen). This change just bumps the queue limit from 100 -> 200 in dc_ghost.c so behavior is the same, just more headroom.

Should be safe since this limit is local to that file and we’re not changing the draw/sort logic, only capacity.