### PR TITLE
Added asset check prior to starting game window

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -183,6 +183,14 @@ static bool run_resource_flow() {
     return are_resources_checked;
 }
 
+/// @brief Checks game assets are present prior to initializing the renderer.
+static void init_game_assets() {
+    while (!run_resource_flow()) {
+        SDL_PumpEvents();
+        SDL_Delay(128);
+    }
+}
+
 static void afs_init() {
     char* file_path = Resources_GetPath("SF33RD.AFS");
     AFS_Init(file_path);
@@ -221,6 +229,7 @@ static int loop() {
     init_windows_console();
 #endif
 
+    init_game_assets();
     SDLApp_Init();
     set_netplay_params();
 


### PR DESCRIPTION
Changed initialization workflow to not display the main game window until the game assets have been successfully configured.

This fixes 2 issues:
1. By default 3sx will launch the game window in full screen mode. Users who do not have a keyboard can now access their desktop UI after 3sx starts to terminate the application when they are stuck in a failed configuration loop.
2. Users on devices that focus one window at a time should now see the SDL dialog windows rather than the main game window when performing the initial setup.