### PR TITLE
Training: Skip the "Press x to pause" menu

### DIFF
--- a/src/sf33rd/Source/Game/menu/menu.c
+++ b/src/sf33rd/Source/Game/menu/menu.c
@@ -4230,7 +4230,7 @@ s32 Pause_Check_Tr(s16 PL_id) {
 
 void Setup_Tr_Pause(struct _TASK* task_ptr) {
     task_ptr->r_no[1] = 2;
-    task_ptr->r_no[2] = 0;
+    task_ptr->r_no[2] = 1;
     task_ptr->r_no[3] = 0;
     task_ptr->free[0] = 60;
     Cursor_Y_Pos[0][0] = 0;
@@ -4312,25 +4312,26 @@ s32 Pause_in_Normal_Tr(struct _TASK* task_ptr) {
         }
 
         switch (IO_Result) {
+        case SWK_START:
         case SWK_EAST:
-            task_ptr->r_no[2] = 0;
+            task_ptr->r_no[2] = 0x63;
+            Exit_Menu = 1;
             Menu_Suicide[0] = 1;
-            SE_selected();
-            break;
+            return 1;
 
         case SWK_SOUTH:
             switch (Menu_Cursor_Y[0]) {
-            case 0:
-                task_ptr->r_no[2] = 0;
+            case 0: // CONTINUE
+                task_ptr->r_no[2] = 0x63;
+                Exit_Menu = 1;
                 Menu_Suicide[0] = 1;
-                SE_selected();
-                break;
+                return 1;
 
-            case 1:
+            case 1: // TRAINING MENU
                 Cursor_Y_Pos[0][0] = 0;
                 return 2;
 
-            case 2:
+            case 2: // EXIT
                 task_ptr->r_no[2]++;
                 SE_selected();
                 Menu_Suicide[0] = 1;


### PR DESCRIPTION
Quick PR to skip the "Press X to pause" menu in training mode. This is the first step in the eventual goal of being able to press start and immediately open the real training menu without resetting the training mode state.
