### PR TITLE
Test Runner Windows Fix

### DIFF
--- a/src/test/test_runner.c
+++ b/src/test/test_runner.c
@@ -103,7 +103,11 @@ static void finish() {
 
 void TestRunner_Prologue() {
     if (frame == SDL_MAX_UINT64) {
-        raise(SIGSTOP);
+        #ifdef SIGSTOP
+            raise(SIGSTOP);
+        #elif defined(_WIN32)
+            __debugbreak();
+        #endif
     }
 
     p1sw_buff = 0;


### PR DESCRIPTION
Debug build on windows was broken, as windows does not have SIGSTOP in it's signal.h

See the issue here: https://discord.com/channels/1425090903630155939/1425090904498110557/1488362134814326875