### PR TITLE
OpenGL: Fix quad overflow

### DIFF
--- a/src/platform/video/opengl/opengl_renderer.c
+++ b/src/platform/video/opengl/opengl_renderer.c
@@ -13,7 +13,7 @@
 
 #include <libgraph.h>
 
-#define QUADS_MAX 512
+#define QUADS_MAX 1024
 
 typedef enum GLPaletteType : Uint8 {
     PALETTE_NONE = 0,


### PR DESCRIPTION
Increased quad limit from 512 to 1024 to prevent overflow when there are many effects on screen