### PR TITLE
Fix draw order of transparent objects

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -285,9 +285,7 @@ void Main_StepFrame() {
     mpp_w.inGame = false;
 
     njUserMain();
-    seqsBeforeProcess();
     njdp2d_draw();
-    seqsAfterProcess();
     KnjFlush();
     disp_effect_work();
     flFlip(0);

--- a/src/platform/video/opengl/opengl_renderer.c
+++ b/src/platform/video/opengl/opengl_renderer.c
@@ -585,6 +585,7 @@ void OpenGLRenderer_RenderFrame(SDL_Rect viewport) {
     glBindFramebuffer(GL_FRAMEBUFFER, canvas_fbo);
     glViewport(0, 0, 384, 224);
 	glEnable(GL_DEPTH_TEST);
+	glDepthFunc(GL_LEQUAL);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     for (int i = 0; i < arrlen(quads); i++) {

--- a/src/sf33rd/Source/Game/rendering/dc_ghost.c
+++ b/src/sf33rd/Source/Game/rendering/dc_ghost.c
@@ -10,6 +10,7 @@
 #include "sf33rd/Source/Common/PPGFile.h"
 #include "sf33rd/Source/Game/rendering/aboutspr.h"
 #include "sf33rd/Source/Game/rendering/color3rd.h"
+#include "sf33rd/Source/Game/rendering/mtrans.h"
 #include "structs.h"
 
 #include "core/renderer.h"
@@ -186,7 +187,9 @@ void njdp2d_draw() {
             break;
 
         case 1:
+			seqsBeforeProcess();
             shadow_drawing((WORK*)njdp2d_w.prim[i].col, njdp2d_w.prim[i].v[0].y);
+			seqsAfterProcess();
             break;
         }
     }

--- a/src/sf33rd/Source/Game/ui/sc_sub.c
+++ b/src/sf33rd/Source/Game/ui/sc_sub.c
@@ -1005,7 +1005,8 @@ void stun_base_put(u8 Pl_Num, s16 len) {
     pos[1].y = pos[0].y;
     pos[2].x = pos[0].x;
     pos[2].y = pos[3].y;
-    njDrawPolygon2D(&vtx, 4, PrioBase[TopHUDFacePriority], 96);
+	// Fudged priority to fix overlap with stun_put
+    njDrawPolygon2D(&vtx, 4, PrioBase[TopHUDFacePriority + 1], 96);
 }
 
 void WipeInit() {


### PR DESCRIPTION
The attempt at drawing stuff in order didn't quite work due to how mtrans defers draws. This fixes some stuff that regressed between dreamcast and ps2.