### PR TITLE
SAS audio backend for PSP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if(PSP)
         CRS_APP_DRIVER_PSP
         CRS_VIDEO_DRIVER_PSP
         CRS_INPUT_DRIVER_SDL
+        CRS_AUDIO_DRIVER_PSP
     )
 else()
     target_compile_definitions(3sx PRIVATE
@@ -90,6 +91,7 @@ else()
         CRS_VIDEO_DRIVER_OPENGL
         $<$<NOT:$<CONFIG:Statcheck>>:CRS_INPUT_DRIVER_SDL>
         $<$<CONFIG:Statcheck>:CRS_INPUT_DRIVER_STATCHECK>
+        CRS_AUDIO_DRIVER_SOFT
 
         ARCADE_ROM
         SOUND_ENABLED
@@ -211,6 +213,7 @@ if(PSP)
         psphprm
         pspctrl
         psppower
+        pspsascore
     )
 else()
     target_link_libraries(3sx PRIVATE

--- a/src/platform/audio/psp/sas.c
+++ b/src/platform/audio/psp/sas.c
@@ -66,21 +66,30 @@ void SPU_Upload(u32 dst, void* src, u32 size) {
 }
 
 void SPU_VoiceStart(int vnum, u32 start_addr) {
-
     // HACK: we don't have the vag size on hand, doesn't seem to be used far ADPCM (on ppssspp at least)
     __sceSasSetVoice(&core, vnum, &ram[start_addr], sizeof(ram), 1);
     __sceSasSetKeyOn(&core, vnum);
 }
 
 void SPU_VoiceSetPitch(int vnum, int pitch) {
-    __sceSasSetPitch(&core, vnum, 48000 * pitch / 44100);
+    // PS2 is 48khz, psp is 44.1, scaling like this should work afaik
+    pitch = 48000 * pitch / 44100;
+
+    __sceSasSetPitch(&core, vnum, pitch);
 }
 
 void SPU_VoiceSetVolume(int vnum, int voll, int volr) {
-    __sceSasSetVolume(&core, vnum, (0x1000 * voll) / 0x3fff, (0x1000 * volr) / 0x3fff, 0, 0);
+    // Scale the volumes from 0 - 0x3fff to 0 - 0x1000
+    voll = (0x1000 * voll) / 0x3fff;
+    volr = (0x1000 * volr) / 0x3fff;
+
+    __sceSasSetVolume(&core, vnum, voll, volr, 0, 0);
 }
 
 void SPU_VoiceSetADSR(int vnum, u16 adsr1, u16 adsr2) {
+    // I'm assuming the they're not going to match the ps2 exactly
+    // but I don't have a method for scaling them at the moment.
+
     __sceSasSetSimpleADSR(&core, vnum, adsr1, adsr2);
 }
 

--- a/src/platform/audio/psp/sas.c
+++ b/src/platform/audio/psp/sas.c
@@ -23,11 +23,7 @@ static void sas_thread() {
     SDL_SetCurrentThreadPriority(SDL_THREAD_PRIORITY_TIME_CRITICAL);
     while (1) {
         user_cb();
-
-        /* Run a SAS cycle, which will update and process the voices. */
         __sceSasCore(&core, mixer);
-
-        /* Finally, output the audio. */
         sceAudioOutputPannedBlocking(channel, PSP_AUDIO_VOLUME_MAX, PSP_AUDIO_VOLUME_MAX, mixer);
     }
 }
@@ -36,26 +32,24 @@ void SPU_Init(void (*cb)()) {
     soundLock = SDL_CreateMutex();
     user_cb = cb;
 
-    /* The following modules must be loaded in order for sceSasCore to work */
     int result = sceUtilityLoadModule(PSP_MODULE_AV_AVCODEC);
     if (result < 0) {
-        SDL_Log("err: 0x%08X\n", result);
+        SDL_Log("Failed to load avcodec (err: 0x%08X)\n", result);
     }
 
     result = sceUtilityLoadModule(PSP_MODULE_AV_SASCORE);
     if (result < 0) {
-        SDL_Log("err: 0x%08X\n", result);
+        SDL_Log("Failed to load sascore (err: 0x%08X)\n", result);
     }
 
-    /* Initialize sceSasCore instance */
     result = __sceSasInit(&core, GRAIN_SIZE, SPU_VOICE_COUNT, PSP_SAS_OUTPUTMODE_STEREO, PSP_SAS_SAMPLE_RATE);
     if (result < 0) {
-        SDL_Log("err: 0x%08X\n", result);
+        SDL_Log("Failed to initialize sas (err: 0x%08X)\n", result);
     }
 
     channel = sceAudioChReserve(PSP_AUDIO_NEXT_CHANNEL, GRAIN_SIZE, PSP_AUDIO_FORMAT_STEREO);
     if (channel < 0) {
-        SDL_Log("Failed to initialize sceAudio channel!. err: 0x%08X\n", channel);
+        SDL_Log("Failed to initialize sceAudio channel! (err: 0x%08X)\n", channel);
     }
 
     SDL_CreateThread(sas_thread, "sas_thread", NULL);

--- a/src/platform/audio/psp/sas.c
+++ b/src/platform/audio/psp/sas.c
@@ -1,0 +1,96 @@
+#ifdef CRS_AUDIO_DRIVER_PSP
+#include "port/sound/spu.h"
+
+#include <SDL3/SDL.h>
+#include <pspaudio.h>
+#include <pspsascore.h>
+#include <psputility.h>
+
+//#define GRAIN_SIZE (PSP_SAS_GRAIN_SIZE)
+#define GRAIN_SIZE 192 
+
+SDL_Mutex* soundLock;
+
+__attribute__((aligned(64))) SceSasCore core;
+__attribute__((aligned(64))) int16_t mixer[GRAIN_SIZE * 4];
+
+static int channel = -1;
+static u16 ram[(2 * 1024 * 1024) >> 1];
+static struct SPUVConf voice[SPU_VOICE_COUNT] = {};
+static void (*user_cb)();
+
+static void sas_thread() {
+    SDL_SetCurrentThreadPriority(SDL_THREAD_PRIORITY_TIME_CRITICAL);
+    while (1) {
+		user_cb();
+
+        /* Run a SAS cycle, which will update and process the voices. */
+        __sceSasCore(&core, mixer);
+
+        /* Finally, output the audio. */
+        sceAudioOutputPannedBlocking(channel, PSP_AUDIO_VOLUME_MAX, PSP_AUDIO_VOLUME_MAX, mixer);
+    }
+}
+
+void SPU_Init(void (*cb)()) {
+    soundLock = SDL_CreateMutex();
+	user_cb = cb;
+
+    /* The following modules must be loaded in order for sceSasCore to work */
+    int result = sceUtilityLoadModule(PSP_MODULE_AV_AVCODEC);
+    if (result < 0) {
+        SDL_Log("err: 0x%08X\n", result);
+    }
+
+    result = sceUtilityLoadModule(PSP_MODULE_AV_SASCORE);
+    if (result < 0) {
+        SDL_Log("err: 0x%08X\n", result);
+    }
+
+    /* Initialize sceSasCore instance */
+    result = __sceSasInit(&core, GRAIN_SIZE, SPU_VOICE_COUNT, PSP_SAS_OUTPUTMODE_STEREO, PSP_SAS_SAMPLE_RATE);
+    if (result < 0) {
+        SDL_Log("err: 0x%08X\n", result);
+    }
+
+    channel = sceAudioChReserve(PSP_AUDIO_NEXT_CHANNEL, GRAIN_SIZE, PSP_AUDIO_FORMAT_STEREO);
+    if (channel < 0) {
+        SDL_Log("Failed to initialize sceAudio channel!. err: 0x%08X\n", channel);
+    }
+
+    SDL_CreateThread(sas_thread, "sas_thread", NULL);
+}
+
+void SPU_Upload(u32 dst, void* src, u32 size) {
+    memcpy(&ram[dst >> 1], src, size);
+}
+
+void SPU_VoiceStart(int vnum, u32 start_addr) {
+    struct SPUVConf* v = &voice[vnum];
+
+    // HACK: we don't have the vag size on hand, doesn't seem to be used far ADPCM (on ppssspp at least)
+    __sceSasSetVoice(&core, vnum, &ram[start_addr], sizeof(ram), 1);
+    __sceSasSetSimpleADSR(&core, vnum, v->adsr1, v->adsr2);
+    __sceSasSetPitch(&core, vnum, 48000 * v->pitch / 44100);
+    __sceSasSetVolume(&core, vnum, (0x1000 * v->voll) / 0x3fff, (0x1000 * v->volr) / 0x3fff, 0, 0);
+
+    __sceSasSetKeyOn(&core, vnum);
+}
+
+void SPU_VoiceSetConf(int vnum, struct SPUVConf* conf) {
+    voice[vnum] = *conf;
+}
+
+bool SPU_VoiceIsFinished(int vnum) {
+    return (__sceSasGetEndFlag(&core) & (1 << vnum)) != 0;
+}
+void SPU_VoiceKeyOff(int vnum) {
+    __sceSasSetKeyOff(&core, vnum);
+}
+
+void SPU_VoiceStop(int vnum) {
+    __sceSasSetKeyOff(&core, vnum);
+    __sceSasSetVolume(&core, vnum, 0, 0, 0, 0);
+}
+
+#endif

--- a/src/platform/audio/psp/sas.c
+++ b/src/platform/audio/psp/sas.c
@@ -65,9 +65,8 @@ void SPU_Upload(u32 dst, void* src, u32 size) {
     memcpy(&ram[dst >> 1], src, size);
 }
 
-void SPU_VoiceStart(int vnum, u32 start_addr) {
-    // HACK: we don't have the vag size on hand, doesn't seem to be used far ADPCM (on ppssspp at least)
-    __sceSasSetVoice(&core, vnum, &ram[start_addr], sizeof(ram), 1);
+void SPU_VoiceStart(int vnum, u32 start_addr, u32 size) {
+    __sceSasSetVoice(&core, vnum, &ram[start_addr], size, 1);
     __sceSasSetKeyOn(&core, vnum);
 }
 

--- a/src/platform/audio/psp/sas.c
+++ b/src/platform/audio/psp/sas.c
@@ -6,8 +6,9 @@
 #include <pspsascore.h>
 #include <psputility.h>
 
-//#define GRAIN_SIZE (PSP_SAS_GRAIN_SIZE)
-#define GRAIN_SIZE 192 
+// Grain size needs to be a multiple of 64, we'd like to call the user cb at 250hz
+// 44100 / 250 = 176.4, so 192 is the closest we'll get.
+#define GRAIN_SIZE 192
 
 SDL_Mutex* soundLock;
 
@@ -16,13 +17,12 @@ __attribute__((aligned(64))) int16_t mixer[GRAIN_SIZE * 4];
 
 static int channel = -1;
 static u16 ram[(2 * 1024 * 1024) >> 1];
-static struct SPUVConf voice[SPU_VOICE_COUNT] = {};
 static void (*user_cb)();
 
 static void sas_thread() {
     SDL_SetCurrentThreadPriority(SDL_THREAD_PRIORITY_TIME_CRITICAL);
     while (1) {
-		user_cb();
+        user_cb();
 
         /* Run a SAS cycle, which will update and process the voices. */
         __sceSasCore(&core, mixer);
@@ -34,7 +34,7 @@ static void sas_thread() {
 
 void SPU_Init(void (*cb)()) {
     soundLock = SDL_CreateMutex();
-	user_cb = cb;
+    user_cb = cb;
 
     /* The following modules must be loaded in order for sceSasCore to work */
     int result = sceUtilityLoadModule(PSP_MODULE_AV_AVCODEC);
@@ -66,19 +66,22 @@ void SPU_Upload(u32 dst, void* src, u32 size) {
 }
 
 void SPU_VoiceStart(int vnum, u32 start_addr) {
-    struct SPUVConf* v = &voice[vnum];
 
     // HACK: we don't have the vag size on hand, doesn't seem to be used far ADPCM (on ppssspp at least)
     __sceSasSetVoice(&core, vnum, &ram[start_addr], sizeof(ram), 1);
-    __sceSasSetSimpleADSR(&core, vnum, v->adsr1, v->adsr2);
-    __sceSasSetPitch(&core, vnum, 48000 * v->pitch / 44100);
-    __sceSasSetVolume(&core, vnum, (0x1000 * v->voll) / 0x3fff, (0x1000 * v->volr) / 0x3fff, 0, 0);
-
     __sceSasSetKeyOn(&core, vnum);
 }
 
-void SPU_VoiceSetConf(int vnum, struct SPUVConf* conf) {
-    voice[vnum] = *conf;
+void SPU_VoiceSetPitch(int vnum, int pitch) {
+    __sceSasSetPitch(&core, vnum, 48000 * pitch / 44100);
+}
+
+void SPU_VoiceSetVolume(int vnum, int voll, int volr) {
+    __sceSasSetVolume(&core, vnum, (0x1000 * voll) / 0x3fff, (0x1000 * volr) / 0x3fff, 0, 0);
+}
+
+void SPU_VoiceSetADSR(int vnum, u16 adsr1, u16 adsr2) {
+    __sceSasSetSimpleADSR(&core, vnum, adsr1, adsr2);
 }
 
 bool SPU_VoiceIsFinished(int vnum) {

--- a/src/port/sound/emlShim.c
+++ b/src/port/sound/emlShim.c
@@ -58,7 +58,7 @@ static short masterVolume;
 static short assignedBankVolume[16];
 static short bankVolume[16];
 
-static struct VWork vpool[48];
+static struct VWork vpool[SPU_VOICE_COUNT];
 
 static LIST_HEAD(active_voices);
 static LIST_HEAD(free_voices);
@@ -207,7 +207,7 @@ void emlShimInit() {
         assignedBankVolume[i] = 0x3fff;
     }
 
-    for (int i = 0; i < 48; i++) {
+    for (int i = 0; i < SPU_VOICE_COUNT; i++) {
         vpool[i].voice_num = i;
         list_init(&vpool[i].list);
         list_insert(&free_voices, &vpool[i].list);

--- a/src/port/sound/emlShim.c
+++ b/src/port/sound/emlShim.c
@@ -487,7 +487,7 @@ void emlShimStartSound(CSE_SYS_PARAM_SNDSTART* param) {
 
     UpdateVolPanPitch(voice);
 
-    SPU_VoiceStart(voice->voice_num, param->phdp.s_addr >> 1);
+    SPU_VoiceStart(voice->voice_num, param->phdp.s_addr >> 1, param->phdp.s_size);
 
     SDL_UnlockMutex(soundLock);
 }

--- a/src/port/sound/emlShim.c
+++ b/src/port/sound/emlShim.c
@@ -343,7 +343,6 @@ static int checkConditions(struct VId* id, CSE_REQP* match, u32 cond) {
 
 static void UpdateVolPanPitch(struct VWork* voice) {
     int volume, bankvol, pan, voll, volr, note, pitch;
-    struct SPUVConf conf;
 
     bankvol = bankVolume[voice->id.bank & 0xf];
     volume = (bankvol * voice->req_vol) / 0x3fff;
@@ -356,13 +355,8 @@ static void UpdateVolPanPitch(struct VWork* voice) {
     voll = 0x3fff * ((volume * (127 - pan)) / 127) / 0x3fff;
     volr = 0x3fff * ((volume * pan) / 127) / 0x3fff;
 
-    conf.pitch = pitch;
-    conf.voll = voll;
-    conf.volr = volr;
-    conf.adsr1 = voice->adsr1;
-    conf.adsr2 = voice->adsr2;
-
-    SPU_VoiceSetConf(voice->voice_num, &conf);
+    SPU_VoiceSetPitch(voice->voice_num, pitch);
+    SPU_VoiceSetVolume(voice->voice_num, voll, volr);
 }
 
 static int getCategoryVoiceNum(CSE_REQP* reqp) {
@@ -485,6 +479,8 @@ void emlShimStartSound(CSE_SYS_PARAM_SNDSTART* param) {
 
     voice->adsr1 = param->phdp.adsr1;
     voice->adsr2 = param->phdp.adsr2;
+
+    SPU_VoiceSetADSR(voice->voice_num, voice->adsr1, voice->adsr2);
 
     InitLfo(&voice->lfo_pitch, 0x6000, 0);
     InitLfo(&voice->lfo_vol, 0x418, 0);

--- a/src/port/sound/spu.c
+++ b/src/port/sound/spu.c
@@ -1,3 +1,5 @@
+#ifdef CRS_AUDIO_DRIVER_SOFT
+
 #include "port/sound/spu.h"
 
 #include "common.h"
@@ -9,8 +11,6 @@
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 #define clamp(val, min, max) (((val) > (max)) ? (max) : (((val) < (min)) ? (min) : (val)))
-
-#define VOICE_COUNT 48
 
 #include "interp_table.inc"
 
@@ -59,9 +59,10 @@ struct SPU_Voice {
 
 SDL_Mutex* soundLock;
 
+static void SPU_Tick(s16* output);
 static void (*timer_cb)();
 static SDL_AudioStream* stream;
-static struct SPU_Voice voices[VOICE_COUNT];
+static struct SPU_Voice voices[SPU_VOICE_COUNT];
 static u16 ram[(2 * 1024 * 1024) >> 1];
 static s16 adpcm_coefs[5][2] = {
     { 0, 0 }, { 60, 0 }, { 115, -52 }, { 98, -55 }, { 122, -60 },
@@ -269,16 +270,6 @@ void SPU_VoiceStop(int vnum) {
     voices[vnum].run = false;
 }
 
-void SPU_VoiceGetConf(int vnum, struct SPUVConf* conf) {
-    struct SPU_Voice* v = &voices[vnum];
-
-    conf->pitch = v->pitch;
-    conf->voll = v->voll;
-    conf->volr = v->volr;
-    conf->adsr1 = v->adsr1;
-    conf->adsr2 = v->adsr2;
-}
-
 void SPU_VoiceSetConf(int vnum, struct SPUVConf* conf) {
     struct SPU_Voice* v = &voices[vnum];
 
@@ -377,12 +368,12 @@ void SPU_Upload(u32 dst, void* src, u32 size) {
     SDL_UnlockMutex(soundLock);
 }
 
-void SPU_Tick(s16* output) {
+static void SPU_Tick(s16* output) {
     struct SPU_Voice* v;
     s32 acc[2] = {};
     s32 vout[2] = {};
 
-    for (int i = 0; i < VOICE_COUNT; i++) {
+    for (int i = 0; i < SPU_VOICE_COUNT; i++) {
         v = &voices[i];
 
         if (v->run) {
@@ -396,3 +387,5 @@ void SPU_Tick(s16* output) {
     output[0] = clamp(acc[0], INT16_MIN, INT16_MAX);
     output[1] = clamp(acc[1], INT16_MIN, INT16_MAX);
 }
+
+#endif

--- a/src/port/sound/spu.c
+++ b/src/port/sound/spu.c
@@ -270,14 +270,24 @@ void SPU_VoiceStop(int vnum) {
     voices[vnum].run = false;
 }
 
-void SPU_VoiceSetConf(int vnum, struct SPUVConf* conf) {
+void SPU_VoiceSetPitch(int vnum, int pitch) {
     struct SPU_Voice* v = &voices[vnum];
 
-    v->pitch = conf->pitch;
-    v->voll = conf->voll << 1;
-    v->volr = conf->volr << 1;
-    v->adsr1 = conf->adsr1;
-    v->adsr2 = conf->adsr2;
+    v->pitch = pitch;
+}
+
+void SPU_VoiceSetVolume(int vnum, int voll, int volr) {
+    struct SPU_Voice* v = &voices[vnum];
+
+    v->voll = voll << 1;
+    v->volr = volr << 1;
+}
+
+void SPU_VoiceSetADSR(int vnum, u16 adsr1, u16 adsr2) {
+    struct SPU_Voice* v = &voices[vnum];
+
+    v->adsr1 = adsr1;
+    v->adsr2 = adsr2;
 }
 
 void SPU_VoiceStart(int vnum, u32 start_addr) {

--- a/src/port/sound/spu.c
+++ b/src/port/sound/spu.c
@@ -290,9 +290,11 @@ void SPU_VoiceSetADSR(int vnum, u16 adsr1, u16 adsr2) {
     v->adsr2 = adsr2;
 }
 
-void SPU_VoiceStart(int vnum, u32 start_addr) {
+void SPU_VoiceStart(int vnum, u32 start_addr, u32 size) {
     struct SPU_Voice* v = &voices[vnum];
     u16 header;
+
+    (void)size;
 
     v->ssa = start_addr;
     v->lsa = start_addr;

--- a/src/port/sound/spu.h
+++ b/src/port/sound/spu.h
@@ -10,13 +10,13 @@ struct SPUVConf {
     u16 adsr1, adsr2;
 };
 
+#define SPU_VOICE_COUNT 24
+
 extern SDL_Mutex* soundLock;
 
 void SPU_Init(void (*cb)());
 void SPU_Upload(u32 dst, void* src, u32 size);
-void SPU_Tick(s16* output);
 void SPU_VoiceStart(int vnum, u32 start_addr);
-void SPU_VoiceGetConf(int vnum, struct SPUVConf* conf);
 void SPU_VoiceSetConf(int vnum, struct SPUVConf* conf);
 bool SPU_VoiceIsFinished(int vnum);
 void SPU_VoiceKeyOff(int vnum);

--- a/src/port/sound/spu.h
+++ b/src/port/sound/spu.h
@@ -4,12 +4,6 @@
 #include "common.h"
 #include <SDL3/SDL_mutex.h>
 
-struct SPUVConf {
-    u32 pitch;
-    u32 voll, volr;
-    u16 adsr1, adsr2;
-};
-
 #define SPU_VOICE_COUNT 24
 
 extern SDL_Mutex* soundLock;
@@ -17,7 +11,9 @@ extern SDL_Mutex* soundLock;
 void SPU_Init(void (*cb)());
 void SPU_Upload(u32 dst, void* src, u32 size);
 void SPU_VoiceStart(int vnum, u32 start_addr);
-void SPU_VoiceSetConf(int vnum, struct SPUVConf* conf);
+void SPU_VoiceSetPitch(int vnum, int pitch);
+void SPU_VoiceSetVolume(int vnum, int voll, int volr);
+void SPU_VoiceSetADSR(int vnum, u16 adsr1, u16 adsr2);
 bool SPU_VoiceIsFinished(int vnum);
 void SPU_VoiceKeyOff(int vnum);
 void SPU_VoiceStop(int vnum);

--- a/src/port/sound/spu.h
+++ b/src/port/sound/spu.h
@@ -10,7 +10,7 @@ extern SDL_Mutex* soundLock;
 
 void SPU_Init(void (*cb)());
 void SPU_Upload(u32 dst, void* src, u32 size);
-void SPU_VoiceStart(int vnum, u32 start_addr);
+void SPU_VoiceStart(int vnum, u32 start_addr, u32 size);
 void SPU_VoiceSetPitch(int vnum, int pitch);
 void SPU_VoiceSetVolume(int vnum, int voll, int volr);
 void SPU_VoiceSetADSR(int vnum, u16 adsr1, u16 adsr2);

--- a/src/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/emlRefPhd.c
+++ b/src/sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/emlRefPhd.c
@@ -145,6 +145,7 @@ s32 CalcPhdParam(CSE_PHDP* pPHDP, CSE_PHDPADDR* pHDPA, u8 note, u32 SpuTopAddr) 
     pPHDP->adsr1 = pHDPA->pSprm->ADSR1;
     pPHDP->adsr2 = pHDPA->pSprm->ADSR2;
     pPHDP->s_addr = SpuTopAddr + pHDPA->pVprm->vagOffset;
+    pPHDP->s_size = SpuTopAddr + pHDPA->pVprm->vagSize;
     pPHDP->freq = pHDPA->pVprm->sampleRate;
     return 0;
 }

--- a/src/structs.h
+++ b/src/structs.h
@@ -1807,6 +1807,7 @@ typedef struct {
     u16 adsr2;
     u32 freq;
     u32 s_addr;
+    u32 s_size;
 } CSE_PHDP;
 
 typedef struct {


### PR DESCRIPTION
The PSP has a software synthesizer that runs on its media engine, it has basically the same interface as the PS1/PS2 SPU's so it's pretty straightforward for us to use it. This PR adds support for using it for sound effects.

Unfortunately I don't have a real PSP so I've only been testing with ppsspp, this is not ideal since their SAS is a re-implementation and might not be identical to the real deal.