### PR TITLE
Headless mode

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -64,6 +64,7 @@ void init_args(int argc, const char* argv[]) {
 #if STATCHECK
         OPT_GROUP("Statcheck"),
         OPT_STRING(0, "states", &args.statcheck.states_path, "Path to states.", NULL, 0, 0),
+        OPT_BOOLEAN(0, "headless", &args.statcheck.headless, "Run the game without a window.", NULL, 0, 0),
 #endif
 
         OPT_END(),

--- a/src/args.h
+++ b/src/args.h
@@ -1,6 +1,8 @@
 #ifndef ARGS_H
 #define ARGS_H
 
+#include <stdbool.h>
+
 #if NETPLAY_ENABLED
 typedef struct NetplayArgs {
     int p2p_local_player;
@@ -13,6 +15,7 @@ typedef struct NetplayArgs {
 #if STATCHECK
 typedef struct StatcheckArgs {
     const char* states_path;
+    bool headless;
 } StatcheckArgs;
 #endif
 

--- a/src/core/renderer.c
+++ b/src/core/renderer.c
@@ -5,13 +5,29 @@
 #include "core/renderer.h"
 
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+#include "args.h"
+
 #include "platform/video/sdl_generic/sdl_generic_renderer.h"
 #elif CRS_VIDEO_DRIVER_PSP
 #include "platform/video/psp/psp_renderer.h"
 #endif
 
+#if CRS_VIDEO_DRIVER_SDL_GENERIC
+static bool skip_rendering() {
+#if STATCHECK
+    return get_args()->statcheck.headless;
+#else
+    return false;
+#endif
+}
+#endif
+
 void Renderer_CreateTexture(unsigned int th) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_CreateTexture(th);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_CreateTexture(th);
@@ -20,6 +36,10 @@ void Renderer_CreateTexture(unsigned int th) {
 
 void Renderer_DestroyTexture(unsigned int texture_handle) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_DestroyTexture(texture_handle);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_DestroyTexture(texture_handle);
@@ -28,6 +48,10 @@ void Renderer_DestroyTexture(unsigned int texture_handle) {
 
 void Renderer_UnlockTexture(unsigned int th) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_UnlockTexture(th);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_UnlockTexture(th);
@@ -36,6 +60,10 @@ void Renderer_UnlockTexture(unsigned int th) {
 
 void Renderer_CreatePalette(unsigned int ph) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_CreatePalette(ph);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_CreatePalette(ph);
@@ -44,6 +72,10 @@ void Renderer_CreatePalette(unsigned int ph) {
 
 void Renderer_DestroyPalette(unsigned int palette_handle) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_DestroyPalette(palette_handle);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_DestroyPalette(palette_handle);
@@ -52,6 +84,10 @@ void Renderer_DestroyPalette(unsigned int palette_handle) {
 
 void Renderer_UnlockPalette(unsigned int th) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_UnlockPalette(th);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_UnlockPalette(th);
@@ -60,6 +96,10 @@ void Renderer_UnlockPalette(unsigned int th) {
 
 void Renderer_SetTexture(unsigned int th) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_SetTexture(th);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_SetTexture(th);
@@ -68,6 +108,10 @@ void Renderer_SetTexture(unsigned int th) {
 
 void Renderer_DrawTexturedQuad(const Sprite* sprite, unsigned int color) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_DrawTexturedQuad(sprite, color);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_DrawTexturedQuad(sprite, color);
@@ -76,6 +120,10 @@ void Renderer_DrawTexturedQuad(const Sprite* sprite, unsigned int color) {
 
 void Renderer_DrawSprite(const Sprite* sprite, unsigned int color) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_DrawSprite(sprite, color);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_DrawSprite(sprite, color);
@@ -84,6 +132,10 @@ void Renderer_DrawSprite(const Sprite* sprite, unsigned int color) {
 
 void Renderer_DrawSprite2(const Sprite2* sprite2) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_DrawSprite2(sprite2);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_DrawSprite2(sprite2);
@@ -92,6 +144,10 @@ void Renderer_DrawSprite2(const Sprite2* sprite2) {
 
 void Renderer_DrawSolidQuad(const Quad* quad, unsigned int color) {
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
+    if (skip_rendering()) {
+        return;
+    }
+
     SDLGenericRenderer_DrawSolidQuad(quad, color);
 #elif CRS_VIDEO_DRIVER_PSP
     PSPRenderer_DrawSolidQuad(quad, color);

--- a/src/platform/app/sdl/sdl_app.c
+++ b/src/platform/app/sdl/sdl_app.c
@@ -31,6 +31,7 @@
 #endif
 
 #if STATCHECK
+#include "platform/app/sdl/sdl_headless_app.h"
 #include "test/test_runner.h"
 #endif
 
@@ -488,6 +489,13 @@ static int loop() {
 
 int main(int argc, const char* argv[]) {
     init_args(argc, argv);
+
+#if STATCHECK
+    if (get_args()->statcheck.headless) {
+        return SDLHeadlessApp_Run();
+    }
+#endif
+
     return loop();
 }
 

--- a/src/platform/app/sdl/sdl_headless_app.c
+++ b/src/platform/app/sdl/sdl_headless_app.c
@@ -1,0 +1,65 @@
+#if CRS_APP_DRIVER_SDL && STATCHECK
+
+#include "platform/app/sdl/sdl_headless_app.h"
+#include "arcade/arcade_balance.h"
+#include "main.h"
+#include "port/config/config.h"
+#include "port/io/afs.h"
+#include "port/resources.h"
+#include "test/test_runner.h"
+
+#include <SDL3/SDL.h>
+
+#include <stdbool.h>
+
+static int init() {
+    Config_Init();
+
+    if (!Resources_Check()) {
+        SDL_Log("Missing or invalid resources: %s", Resources_GetAFSPath());
+        return 1;
+    }
+
+    ArcadeBalance_Init();
+
+    if (!AFS_Init(Resources_GetAFSPath(), 256 * 1024)) {
+        SDL_Log("Couldn't initialize AFS: %s", Resources_GetAFSPath());
+        return 1;
+    }
+
+    Main_Init();
+    return 0;
+}
+
+static void cleanup() {
+    AFS_Finish();
+    Config_Destroy();
+}
+
+static void begin_frame() {
+    TestRunner_Prologue();
+    AFS_RunServer();
+}
+
+static void end_frame() {
+    TestRunner_Epilogue();
+}
+
+int SDLHeadlessApp_Run() {
+    if (init() != 0) {
+        Config_Destroy();
+        return 1;
+    }
+
+    while (true) {
+        begin_frame();
+        Main_StepFrame();
+        end_frame();
+        Main_FinishFrame();
+    }
+
+    cleanup();
+    return 0;
+}
+
+#endif // CRS_APP_DRIVER_SDL && STATCHECK

--- a/src/platform/app/sdl/sdl_headless_app.h
+++ b/src/platform/app/sdl/sdl_headless_app.h
@@ -1,0 +1,6 @@
+#ifndef SDL_HEADLESS_APP_H
+#define SDL_HEADLESS_APP_H
+
+int SDLHeadlessApp_Run();
+
+#endif

--- a/src/port/sound/adx.c
+++ b/src/port/sound/adx.c
@@ -62,6 +62,10 @@ static int num_tracks = 0;
 static int first_track_index = 0;
 static bool has_tracks = false;
 
+static bool audio_available() {
+    return stream != NULL;
+}
+
 static int stream_data_needed() {
     return MIN_QUEUED_DATA - SDL_GetAudioStreamQueued(stream);
 }
@@ -348,6 +352,10 @@ static ADXTrack* alloc_track() {
 }
 
 void ADX_ProcessTracks() {
+    if (!audio_available()) {
+        return;
+    }
+
     const int first_track_index_old = first_track_index;
     const int num_tracks_old = num_tracks;
 
@@ -375,14 +383,27 @@ void ADX_ProcessTracks() {
 void ADX_Init() {
     const SDL_AudioSpec spec = { .format = SDL_AUDIO_S16, .channels = N_CHANNELS, .freq = SAMPLE_RATE };
     stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+
+    if (stream == NULL) {
+        SDL_Log("Failed to create audio stream: %s; continuing without sound", SDL_GetError());
+    }
 }
 
 void ADX_Exit() {
+    if (!audio_available()) {
+        return;
+    }
+
     ADX_Stop();
     SDL_DestroyAudioStream(stream);
+    stream = NULL;
 }
 
 void ADX_Stop() {
+    if (!audio_available()) {
+        return;
+    }
+
     ADX_Pause(true);
     SDL_ClearAudioStream(stream);
 
@@ -397,10 +418,18 @@ void ADX_Stop() {
 }
 
 int ADX_IsPaused() {
+    if (!audio_available()) {
+        return 1;
+    }
+
     return SDL_AudioStreamDevicePaused(stream);
 }
 
 void ADX_Pause(int pause) {
+    if (!audio_available()) {
+        return;
+    }
+
     if (pause) {
         SDL_PauseAudioStreamDevice(stream);
     } else {
@@ -409,6 +438,10 @@ void ADX_Pause(int pause) {
 }
 
 void ADX_StartMem(void* buf, size_t size) {
+    if (!audio_available()) {
+        return;
+    }
+
     ADX_Stop();
 
     ADXTrack* track = alloc_track();
@@ -416,15 +449,27 @@ void ADX_StartMem(void* buf, size_t size) {
 }
 
 int ADX_GetNumFiles() {
+    if (!audio_available()) {
+        return 0;
+    }
+
     return num_tracks;
 }
 
 void ADX_EntryAfs(int file_id) {
+    if (!audio_available()) {
+        return;
+    }
+
     ADXTrack* track = alloc_track();
     track_init(track, file_id, NULL, 0, false);
 }
 
 void ADX_StartSeamless() {
+    if (!audio_available()) {
+        return;
+    }
+
     ADX_Pause(false);
 }
 
@@ -433,6 +478,10 @@ void ADX_ResetEntry() {
 }
 
 void ADX_StartAfs(int file_id) {
+    if (!audio_available()) {
+        return;
+    }
+
     ADX_Stop();
 
     ADXTrack* track = alloc_track();
@@ -440,6 +489,10 @@ void ADX_StartAfs(int file_id) {
 }
 
 void ADX_SetOutVol(int volume) {
+    if (!audio_available()) {
+        return;
+    }
+
     // Convert volume (dB * 10) to linear gain
     const float gain = powf(10.0f, volume / 200.0f);
     SDL_SetAudioStreamGain(stream, gain);
@@ -450,6 +503,10 @@ void ADX_SetMono(bool mono) {
 }
 
 ADXState ADX_GetState() {
+    if (!audio_available()) {
+        return ADX_STATE_STOP;
+    }
+
     if (!has_tracks) {
         return ADX_STATE_STOP;
     }


### PR DESCRIPTION
Added a headless mode for statcheck. In this mode the game doesn't initialize most SDL subsystems: audio, video, gamepads. The game should run faster in this mode, which will speed up statchecking multiple replays