### PR TITLE
Statcheck: Test tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,6 @@ project(3sx LANGUAGES C CXX)
 include(${PROJECT_SOURCE_DIR}/cmake/imgui_sources.cmake)
 
 set(THREESX_CONFIGURATIONS Debug Release RelWithDebInfo MinSizeRel)
-if(NOT PSP)
-    list(APPEND THREESX_CONFIGURATIONS Statcheck)
-endif()
-
 get_property(THREESX_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(THREESX_IS_MULTI_CONFIG)
     set(CMAKE_CONFIGURATION_TYPES "${THREESX_CONFIGURATIONS}" CACHE STRING "Available build types" FORCE)
@@ -15,18 +11,16 @@ else()
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${THREESX_CONFIGURATIONS}")
 endif()
 
-set(CMAKE_C_FLAGS_STATCHECK "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-set(CMAKE_CXX_FLAGS_STATCHECK "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-set(CMAKE_EXE_LINKER_FLAGS_STATCHECK "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO}")
-set(CMAKE_SHARED_LINKER_FLAGS_STATCHECK "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO}")
-set(CMAKE_MODULE_LINKER_FLAGS_STATCHECK "${CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO}")
-
 # ======================================
 # Options and platform setup
 # ======================================
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+
+if(NOT PSP)
+    option(THREESX_STATCHECK "Build with replay statcheck support" OFF)
+endif()
 
 # ======================================
 # Include directories
@@ -76,9 +70,9 @@ else()
         $<$<CONFIG:Debug>:NETPLAY_ENABLED>
 
         $<$<CONFIG:Release>:RELEASE>
-        $<$<CONFIG:Release>:CHECKSUM>
+        $<$<AND:$<CONFIG:Release>,$<NOT:$<BOOL:${THREESX_STATCHECK}>>>:CHECKSUM>
         
-        $<$<CONFIG:Statcheck>:STATCHECK>
+        $<$<BOOL:${THREESX_STATCHECK}>:STATCHECK>
 
         # GekkoNet is a pre-built static lib; these were previously propagated by its cmake target
         GEKKONET_STATIC
@@ -88,8 +82,8 @@ else()
         CRS_VIDEO_DRIVER_SDL_GENERIC
         CRS_VIDEO_DRIVER_SDL_GPU
         CRS_VIDEO_DRIVER_OPENGL
-        $<$<NOT:$<CONFIG:Statcheck>>:CRS_INPUT_DRIVER_SDL>
-        $<$<CONFIG:Statcheck>:CRS_INPUT_DRIVER_STATCHECK>
+        $<$<NOT:$<BOOL:${THREESX_STATCHECK}>>:CRS_INPUT_DRIVER_SDL>
+        $<$<BOOL:${THREESX_STATCHECK}>:CRS_INPUT_DRIVER_STATCHECK>
 
         ARCADE_ROM
         SOUND_ENABLED
@@ -141,10 +135,10 @@ target_compile_options(3sx PRIVATE
 
     ${DISABLED_WARNINGS}
 
-    $<$<OR:$<CONFIG:Debug>,$<CONFIG:Statcheck>>:-Wno-unused-function>
+    $<$<OR:$<CONFIG:Debug>,$<BOOL:${THREESX_STATCHECK}>>:-Wno-unused-function>
     # $<$<CONFIG:Debug>:-Wno-unused-variable>
     -Wno-unused-variable
-    $<$<OR:$<CONFIG:Debug>,$<CONFIG:Statcheck>>:-Wno-unused-but-set-variable>
+    $<$<OR:$<CONFIG:Debug>,$<BOOL:${THREESX_STATCHECK}>>:-Wno-unused-but-set-variable>
 )
 
 if(PSP)
@@ -250,8 +244,8 @@ elseif(WIN32)
         iphlpapi
     )
     target_link_options(3sx PRIVATE
-        "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>,$<CONFIG:Statcheck>>:--for-linker>"
-        "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>,$<CONFIG:Statcheck>>:--pdb=3sx.pdb>"
+        "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:--for-linker>"
+        "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:--pdb=3sx.pdb>"
     )
 elseif(UNIX)
     target_link_libraries(3sx PRIVATE
@@ -323,7 +317,7 @@ elseif(WIN32)
 	)
 
     install(FILES
-        "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>,$<CONFIG:Statcheck>>:${CMAKE_CURRENT_BINARY_DIR}/3sx.pdb>"
+        "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:${CMAKE_CURRENT_BINARY_DIR}/3sx.pdb>"
         DESTINATION bin
     )
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -54,11 +54,19 @@ You should be able to build the project with just Xcode Command Line Tools.
     cmake --install build --prefix build/application
     ```
 
-    For the dedicated static-analysis configuration, use `Statcheck` instead:
+    Enable replay statcheck independently of the build configuration. For example,
+    use `RelWithDebInfo` for routine runs:
 
     ```bash
-    CC=clang CXX=clang++ cmake -B build-statcheck -DCMAKE_BUILD_TYPE=Statcheck
-    cmake --build build-statcheck --parallel --config Statcheck
+    CC=clang CXX=clang++ cmake -B build-statcheck -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTHREESX_STATCHECK=ON
+    cmake --build build-statcheck --parallel --config RelWithDebInfo
+    ```
+
+    For debugger-friendly statcheck runs, configure a Debug build instead:
+
+    ```bash
+    CC=clang CXX=clang++ cmake -B build-statcheck-debug -DCMAKE_BUILD_TYPE=Debug -DTHREESX_STATCHECK=ON
+    cmake --build build-statcheck-debug --parallel --config Debug
     ```
 
 3. Copy from build/application to the desired location

--- a/src/port/utils.c
+++ b/src/port/utils.c
@@ -77,17 +77,3 @@ void debug_print(const char* fmt, ...) {
     va_end(args);
 #endif
 }
-
-void stop_if(bool condition) {
-#if DEBUG
-    if (!condition) {
-        return;
-    }
-
-#if _WIN32
-    __debugbreak();
-#elif __APPLE__ || linux
-    raise(SIGSTOP);
-#endif
-#endif
-}

--- a/src/port/utils.h
+++ b/src/port/utils.h
@@ -10,6 +10,5 @@
 __dead2 void fatal_error(const char* fmt, ...);
 __dead2 void not_implemented(const char* func);
 void debug_print(const char* fmt, ...);
-void stop_if(bool condition);
 
 #endif

--- a/src/test/test_runner_compare.c
+++ b/src/test/test_runner_compare.c
@@ -13,6 +13,7 @@
 
 #include <SDL3/SDL.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 
 #if _WIN32
@@ -31,6 +32,7 @@ static void stop_if(bool condition) {
         return;
     }
 
+    // FIXME: Depending on args directly is dirty, but I don't wanna deal with injecting this right now
     if (get_args()->statcheck.headless) {
         exit(1);
     } else {
@@ -41,6 +43,23 @@ static void stop_if(bool condition) {
 #endif
     }
 }
+
+#define assert_equals(actual, expected)                                                                                \
+    do {                                                                                                               \
+        if ((actual) != (expected)) {                                                                                  \
+            fprintf(                                                                                                   \
+                stderr,                                                                                                \
+                "%s:%d: %s (%lld) != %s (%lld)\n",                                                                     \
+                __FILE__,                                                                                              \
+                __LINE__,                                                                                              \
+                #actual,                                                                                               \
+                (long long)(actual),                                                                                   \
+                #expected,                                                                                             \
+                (long long)(expected)                                                                                  \
+            );                                                                                                         \
+            stop_if(true);                                                                                             \
+        }                                                                                                              \
+    } while (0)
 
 // Data reading
 
@@ -140,18 +159,18 @@ static void read_t_pl_lvr(SDL_IOStream* io, T_PL_LVR dst[2]) {
 
 static void compare_main_values(SDL_IOStream* io) {
     const u8 allow_a_battle_f_cps3 = read_allow_a_battle_f(io);
-    stop_if(Allow_a_battle_f != allow_a_battle_f_cps3);
+    assert_equals(Allow_a_battle_f, allow_a_battle_f_cps3);
 
     const u8 round_timer_cps3 = read_u8(io, ROUND_TIMER_OFFSET);
-    stop_if(round_timer != round_timer_cps3);
+    assert_equals(round_timer, round_timer_cps3);
 
     for (int i = 0; i < 2; i++) {
         const Sint64 plw_offset = calc_plw_offset(i);
 
         const Position pos_3sx = get_position(i);
         const Position pos_cps3 = read_position(io, i);
-        stop_if(pos_3sx.x != pos_cps3.x);
-        stop_if(pos_3sx.y != pos_cps3.y);
+        assert_equals(pos_3sx.x, pos_cps3.x);
+        assert_equals(pos_3sx.y, pos_cps3.y);
 
         // if (i == 0) {
         //     printf("🔴 %llu pos x: %d vs %d\n", frame, pos_cps3.x, pos_3sx.x);
@@ -159,55 +178,55 @@ static void compare_main_values(SDL_IOStream* io) {
 
         const s16 vital_new_3sx = plw[i].wu.vital_new;
         const s16 vital_new_cps3 = read_s16(io, plw_offset + WORK_VITAL_NEW_OFFSET);
-        stop_if(vital_new_3sx != vital_new_cps3);
+        assert_equals(vital_new_3sx, vital_new_cps3);
 
         const s16 stun_3sx = piyori_type[i].now.quantity.h;
         const s16 stun_cps3 = read_s16(io, PIYORI_TYPE_OFFSET + i * sizeof(PiyoriType) + offsetof(PiyoriType, now));
-        stop_if(stun_3sx != stun_cps3);
+        assert_equals(stun_3sx, stun_cps3);
 
         const s16 sa_gauge_3sx = super_arts[i].gauge.s.h;
         const s16 sa_gauge_cps3 = read_s16(io, SUPER_ARTS_WORK_OFFSET + i * sizeof(SA_WORK) + offsetof(SA_WORK, gauge));
-        stop_if(sa_gauge_3sx != sa_gauge_cps3);
+        assert_equals(sa_gauge_3sx, sa_gauge_cps3);
 
         const s16 sa_store_3sx = super_arts[i].store;
         const s16 sa_store_cps3 = read_s16(io, SUPER_ARTS_WORK_OFFSET + i * sizeof(SA_WORK) + offsetof(SA_WORK, store));
-        stop_if(sa_store_3sx != sa_store_cps3);
+        assert_equals(sa_store_3sx, sa_store_cps3);
     }
 }
 
 static void compare_service_values(SDL_IOStream* io, bool compare_characters, Uint64 frame) {
     const u16 game_timer_cps3 = read_game_timer(io);
-    stop_if(Game_timer != game_timer_cps3);
+    assert_equals(Game_timer, game_timer_cps3);
 
     const s16 counter_hi_cps3 = read_s16(io, COUNTER_HI_OFFSET);
-    stop_if(Counter_hi != counter_hi_cps3);
+    assert_equals(Counter_hi, counter_hi_cps3);
 
     const s16 counter_low_cps3 = read_s16(io, COUNTER_LOW_OFFSET);
-    stop_if(Counter_low != counter_low_cps3);
+    assert_equals(Counter_low, counter_low_cps3);
 
     const s16 random_ix16_cps3 = read_s16(io, RANDOM_IX_16_OFFSET);
     // This is dirty, but syncing Random_ix16 every frame helps avoid animation-related desyncs
     Random_ix16 = random_ix16_cps3;
 
     const s16 random_ix32_cps3 = read_s16(io, RANDOM_IX_32_OFFSET);
-    stop_if(Random_ix32 != random_ix32_cps3);
+    assert_equals(Random_ix32, random_ix32_cps3);
 
     const u8 cmb_stock_0_cps3 = read_u8(io, CMB_STOCK_OFFSET);
     const u8 cmb_stock_1_cps3 = read_u8(io, CMB_STOCK_OFFSET + 1);
-    stop_if(cmb_stock[0] != cmb_stock_0_cps3);
-    stop_if(cmb_stock[1] != cmb_stock_1_cps3);
+    assert_equals(cmb_stock[0], cmb_stock_0_cps3);
+    assert_equals(cmb_stock[1], cmb_stock_1_cps3);
 
     const u8 cmb_all_stock_cps3 = read_u8(io, CMB_ALL_STOCK_OFFSET);
-    stop_if(cmb_all_stock[0] != cmb_all_stock_cps3);
+    assert_equals(cmb_all_stock[0], cmb_all_stock_cps3);
 
     for (int i = 0; i < 4; i++) {
         const u16 c_no_cps3 = read_u16(io, C_NO_OFFSET + i * sizeof(u16));
-        stop_if(C_No[i] != c_no_cps3);
+        assert_equals(C_No[i], c_no_cps3);
 
         const u16 g_no_cps3 = read_u16(io, G_NO_OFFSET + i * sizeof(u16));
 
         if (i != 0) {
-            stop_if(G_No[i] != g_no_cps3);
+            assert_equals(G_No[i], g_no_cps3);
         }
     }
 
@@ -223,37 +242,37 @@ static void compare_service_values(SDL_IOStream* io, bool compare_characters, Ui
 
         const u8 caution_flag_3sx = plw[i].caution_flag;
         const u8 caution_flag_cps3 = read_u8(io, plw_offset + PLW_CAUTION_FLAG_OFFSET);
-        stop_if(caution_flag_3sx != caution_flag_cps3);
+        assert_equals(caution_flag_3sx, caution_flag_cps3);
 
         const u8 do_not_move_3sx = plw[i].do_not_move;
         const u8 do_not_move_cps3 = read_u8(io, plw_offset + PLW_DO_NOT_MOVE_OFFSET);
-        stop_if(do_not_move_3sx != do_not_move_cps3);
+        assert_equals(do_not_move_3sx, do_not_move_cps3);
 
         for (int j = 0; j < 8; j++) {
             const s16 routine_no_3sx = plw[i].wu.routine_no[j];
             const s16 routine_no_cps3 = read_s16(io, plw_offset + WORK_ROUTINE_NO_OFFSET + j * 2);
-            stop_if(routine_no_3sx != routine_no_cps3);
+            assert_equals(routine_no_3sx, routine_no_cps3);
         }
 
         const s16 dm_stop_3sx = plw[i].wu.dm_stop;
         const s16 dm_stop_cps3 = read_s16(io, plw_offset + WORK_DM_STOP_OFFSET);
-        stop_if(dm_stop_3sx != dm_stop_cps3);
+        assert_equals(dm_stop_3sx, dm_stop_cps3);
 
         const s16 hit_stop_3sx = plw[i].wu.hit_stop;
         const s16 hit_stop_cps3 = read_s16(io, plw_offset + WORK_HIT_STOP_OFFSET);
-        stop_if(hit_stop_3sx != hit_stop_cps3);
+        assert_equals(hit_stop_3sx, hit_stop_cps3);
 
         const u8 sa_stop_flag_3sx = plw[i].sa_stop_flag;
         const u8 sa_stop_flag_cps3 = read_u8(io, plw_offset + PLW_SA_STOP_FLAG_OFFSET);
-        stop_if(sa_stop_flag_3sx != sa_stop_flag_cps3);
+        assert_equals(sa_stop_flag_3sx, sa_stop_flag_cps3);
 
         // const u16 cg_ix_cps3 = read_u16(io, plw_offset + WORK_CG_IX_OFFSET);
         // const u16 cg_ix_3sx = plw[i].wu.cg_ix;
-        // stop_if(cg_ix_cps3 != cg_ix_3sx);
+        // assert_equals(cg_ix_3sx, cg_ix_cps3);
 
         const u16 cg_add_xy_cps3 = read_u16(io, plw_offset + WORK_CG_ADD_XY_OFFSET);
         const u16 cg_add_xy_3sx = plw[i].wu.cg_add_xy;
-        stop_if(cg_add_xy_3sx != cg_add_xy_cps3);
+        assert_equals(cg_add_xy_3sx, cg_add_xy_cps3);
     }
 }
 
@@ -265,40 +284,40 @@ static void compare_lvr(SDL_IOStream* io) {
         const T_PL_LVR* lvr_cps3 = &t_pl_lvr_cps3[i];
         const T_PL_LVR* lvr_3sx = &t_pl_lvr[i];
 
-        stop_if(lvr_3sx->sw_new != lvr_cps3->sw_new);
-        stop_if(lvr_3sx->sw_old != lvr_cps3->sw_old);
-        stop_if(lvr_3sx->sw_chg != lvr_cps3->sw_chg);
-        stop_if(lvr_3sx->sw_now != lvr_cps3->sw_now);
-        stop_if(lvr_3sx->old_now != lvr_cps3->old_now);
-        stop_if(lvr_3sx->now_lvbt != lvr_cps3->now_lvbt);
-        stop_if(lvr_3sx->old_lvbt != lvr_cps3->old_lvbt);
-        stop_if(lvr_3sx->new_lvbt != lvr_cps3->new_lvbt);
-        stop_if(lvr_3sx->sw_lever != lvr_cps3->sw_lever);
-        stop_if(lvr_3sx->shot_up != lvr_cps3->shot_up);
-        stop_if(lvr_3sx->shot_down != lvr_cps3->shot_down);
-        stop_if(lvr_3sx->shot_ud != lvr_cps3->shot_ud);
-        stop_if(lvr_3sx->lvr_status != lvr_cps3->lvr_status);
-        stop_if(lvr_3sx->jaku_cnt != lvr_cps3->jaku_cnt);
-        stop_if(lvr_3sx->chuu_cnt != lvr_cps3->chuu_cnt);
-        stop_if(lvr_3sx->kyou_cnt != lvr_cps3->kyou_cnt);
-        stop_if(lvr_3sx->up_cnt != lvr_cps3->up_cnt);
-        stop_if(lvr_3sx->down_cnt != lvr_cps3->down_cnt);
-        stop_if(lvr_3sx->left_cnt != lvr_cps3->left_cnt);
-        stop_if(lvr_3sx->right_cnt != lvr_cps3->right_cnt);
-        stop_if(lvr_3sx->s1_cnt != lvr_cps3->s1_cnt);
-        stop_if(lvr_3sx->s2_cnt != lvr_cps3->s2_cnt);
-        stop_if(lvr_3sx->s3_cnt != lvr_cps3->s3_cnt);
-        stop_if(lvr_3sx->s4_cnt != lvr_cps3->s4_cnt);
-        stop_if(lvr_3sx->s5_cnt != lvr_cps3->s5_cnt);
-        stop_if(lvr_3sx->s6_cnt != lvr_cps3->s6_cnt);
-        stop_if(lvr_3sx->lu_cnt != lvr_cps3->lu_cnt);
-        stop_if(lvr_3sx->ld_cnt != lvr_cps3->ld_cnt);
-        stop_if(lvr_3sx->ru_cnt != lvr_cps3->ru_cnt);
-        stop_if(lvr_3sx->rd_cnt != lvr_cps3->rd_cnt);
-        stop_if(lvr_3sx->waza_num != lvr_cps3->waza_num);
-        // stop_if(lvr_3sx->waza_no != lvr_cps3->waza_no);
-        stop_if(lvr_3sx->wait_cnt != lvr_cps3->wait_cnt);
-        stop_if(lvr_3sx->cmd_r_no != lvr_cps3->cmd_r_no);
+        assert_equals(lvr_3sx->sw_new, lvr_cps3->sw_new);
+        assert_equals(lvr_3sx->sw_old, lvr_cps3->sw_old);
+        assert_equals(lvr_3sx->sw_chg, lvr_cps3->sw_chg);
+        assert_equals(lvr_3sx->sw_now, lvr_cps3->sw_now);
+        assert_equals(lvr_3sx->old_now, lvr_cps3->old_now);
+        assert_equals(lvr_3sx->now_lvbt, lvr_cps3->now_lvbt);
+        assert_equals(lvr_3sx->old_lvbt, lvr_cps3->old_lvbt);
+        assert_equals(lvr_3sx->new_lvbt, lvr_cps3->new_lvbt);
+        assert_equals(lvr_3sx->sw_lever, lvr_cps3->sw_lever);
+        assert_equals(lvr_3sx->shot_up, lvr_cps3->shot_up);
+        assert_equals(lvr_3sx->shot_down, lvr_cps3->shot_down);
+        assert_equals(lvr_3sx->shot_ud, lvr_cps3->shot_ud);
+        assert_equals(lvr_3sx->lvr_status, lvr_cps3->lvr_status);
+        assert_equals(lvr_3sx->jaku_cnt, lvr_cps3->jaku_cnt);
+        assert_equals(lvr_3sx->chuu_cnt, lvr_cps3->chuu_cnt);
+        assert_equals(lvr_3sx->kyou_cnt, lvr_cps3->kyou_cnt);
+        assert_equals(lvr_3sx->up_cnt, lvr_cps3->up_cnt);
+        assert_equals(lvr_3sx->down_cnt, lvr_cps3->down_cnt);
+        assert_equals(lvr_3sx->left_cnt, lvr_cps3->left_cnt);
+        assert_equals(lvr_3sx->right_cnt, lvr_cps3->right_cnt);
+        assert_equals(lvr_3sx->s1_cnt, lvr_cps3->s1_cnt);
+        assert_equals(lvr_3sx->s2_cnt, lvr_cps3->s2_cnt);
+        assert_equals(lvr_3sx->s3_cnt, lvr_cps3->s3_cnt);
+        assert_equals(lvr_3sx->s4_cnt, lvr_cps3->s4_cnt);
+        assert_equals(lvr_3sx->s5_cnt, lvr_cps3->s5_cnt);
+        assert_equals(lvr_3sx->s6_cnt, lvr_cps3->s6_cnt);
+        assert_equals(lvr_3sx->lu_cnt, lvr_cps3->lu_cnt);
+        assert_equals(lvr_3sx->ld_cnt, lvr_cps3->ld_cnt);
+        assert_equals(lvr_3sx->ru_cnt, lvr_cps3->ru_cnt);
+        assert_equals(lvr_3sx->rd_cnt, lvr_cps3->rd_cnt);
+        assert_equals(lvr_3sx->waza_num, lvr_cps3->waza_num);
+        // assert_equals(lvr_3sx->waza_no, lvr_cps3->waza_no);
+        assert_equals(lvr_3sx->wait_cnt, lvr_cps3->wait_cnt);
+        assert_equals(lvr_3sx->cmd_r_no, lvr_cps3->cmd_r_no);
     }
 }
 
@@ -311,18 +330,18 @@ static void compare_waza_work(SDL_IOStream* io) {
             const WAZA_WORK* w_3sx = &waza_work[i][j];
             const WAZA_WORK* w_cps3 = &waza_work_cps3[i][j];
 
-            stop_if(w_3sx->w_type != w_cps3->w_type);
-            stop_if(w_3sx->w_int != w_cps3->w_int);
-            stop_if(w_3sx->free1 != w_cps3->free1);
-            stop_if(w_3sx->w_lvr != w_cps3->w_lvr);
-            stop_if(w_3sx->free2 != w_cps3->free2);
-            stop_if(w_3sx->w_dead != w_cps3->w_dead);
-            stop_if(w_3sx->w_dead2 != w_cps3->w_dead2);
-            stop_if(w_3sx->uni0.tame.flag != w_cps3->uni0.tame.flag);
-            stop_if(w_3sx->uni0.tame.shot_flag != w_cps3->uni0.tame.shot_flag);
-            stop_if(w_3sx->uni0.tame.shot_flag2 != w_cps3->uni0.tame.shot_flag2);
-            stop_if(w_3sx->free3 != w_cps3->free3);
-            stop_if(w_3sx->shot_ok != w_cps3->shot_ok);
+            assert_equals(w_3sx->w_type, w_cps3->w_type);
+            assert_equals(w_3sx->w_int, w_cps3->w_int);
+            assert_equals(w_3sx->free1, w_cps3->free1);
+            assert_equals(w_3sx->w_lvr, w_cps3->w_lvr);
+            assert_equals(w_3sx->free2, w_cps3->free2);
+            assert_equals(w_3sx->w_dead, w_cps3->w_dead);
+            assert_equals(w_3sx->w_dead2, w_cps3->w_dead2);
+            assert_equals(w_3sx->uni0.tame.flag, w_cps3->uni0.tame.flag);
+            assert_equals(w_3sx->uni0.tame.shot_flag, w_cps3->uni0.tame.shot_flag);
+            assert_equals(w_3sx->uni0.tame.shot_flag2, w_cps3->uni0.tame.shot_flag2);
+            assert_equals(w_3sx->free3, w_cps3->free3);
+            assert_equals(w_3sx->shot_ok, w_cps3->shot_ok);
         }
     }
 }
@@ -333,39 +352,39 @@ static void compare_wcp(SDL_IOStream* io) {
 
     for (int i = 0; i < 2; i++) {
         const s16 waza_type_cps3 = read_s16(io, WAZA_TYPE_OFFSET + i * sizeof(s16));
-        stop_if(waza_type[i] != waza_type_cps3);
+        assert_equals(waza_type[i], waza_type_cps3);
 
         const WORK_CP* w_3sx = &wcp[i];
         const WORK_CP* w_cps3 = &wcp_cps3[i];
 
-        stop_if(w_3sx->sw_lvbt != w_cps3->sw_lvbt);
-        stop_if(w_3sx->sw_new != w_cps3->sw_new);
-        stop_if(w_3sx->sw_old != w_cps3->sw_old);
-        stop_if(w_3sx->sw_now != w_cps3->sw_now);
-        stop_if(w_3sx->sw_off != w_cps3->sw_off);
-        stop_if(w_3sx->sw_chg != w_cps3->sw_chg);
-        stop_if(w_3sx->old_now != w_cps3->old_now);
-        stop_if(w_3sx->lgp != w_cps3->lgp);
-        stop_if(w_3sx->ca14 != w_cps3->ca14);
-        stop_if(w_3sx->ca25 != w_cps3->ca25);
-        stop_if(w_3sx->ca36 != w_cps3->ca36);
-        stop_if(w_3sx->calf != w_cps3->calf);
-        stop_if(w_3sx->calr != w_cps3->calr);
-        stop_if(w_3sx->lever_dir != w_cps3->lever_dir);
+        assert_equals(w_3sx->sw_lvbt, w_cps3->sw_lvbt);
+        assert_equals(w_3sx->sw_new, w_cps3->sw_new);
+        assert_equals(w_3sx->sw_old, w_cps3->sw_old);
+        assert_equals(w_3sx->sw_now, w_cps3->sw_now);
+        assert_equals(w_3sx->sw_off, w_cps3->sw_off);
+        assert_equals(w_3sx->sw_chg, w_cps3->sw_chg);
+        assert_equals(w_3sx->old_now, w_cps3->old_now);
+        assert_equals(w_3sx->lgp, w_cps3->lgp);
+        assert_equals(w_3sx->ca14, w_cps3->ca14);
+        assert_equals(w_3sx->ca25, w_cps3->ca25);
+        assert_equals(w_3sx->ca36, w_cps3->ca36);
+        assert_equals(w_3sx->calf, w_cps3->calf);
+        assert_equals(w_3sx->calr, w_cps3->calr);
+        assert_equals(w_3sx->lever_dir, w_cps3->lever_dir);
 
         for (int j = 0; j < 56; j++) {
-            stop_if(w_3sx->waza_flag[j] != w_cps3->waza_flag[j]);
+            assert_equals(w_3sx->waza_flag[j], w_cps3->waza_flag[j]);
 
             if (w_3sx->waza_flag[j] == -1) {
                 continue;
             }
 
-            stop_if(w_3sx->reset[j] != w_cps3->reset[j]);
-            stop_if(w_3sx->btix[j] != w_cps3->btix[j]);
+            assert_equals(w_3sx->reset[j], w_cps3->reset[j]);
+            assert_equals(w_3sx->btix[j], w_cps3->btix[j]);
 
             for (int k = 0; k < 4; k++) {
-                stop_if(w_3sx->waza_r[j][k] != w_cps3->waza_r[j][k]);
-                stop_if(w_3sx->exdt[j][k] != w_cps3->exdt[j][k]);
+                assert_equals(w_3sx->waza_r[j][k], w_cps3->waza_r[j][k]);
+                assert_equals(w_3sx->exdt[j][k], w_cps3->exdt[j][k]);
             }
         }
     }

--- a/src/test/test_runner_compare.c
+++ b/src/test/test_runner_compare.c
@@ -2,23 +2,45 @@
 
 #include "test/test_runner_compare.h"
 #include "arcade/arcade_constants.h"
+#include "args.h"
 #include "constants.h"
-#include "port/utils.h"
+#include "sf33rd/Source/Game/engine/cmb_win.h"
 #include "sf33rd/Source/Game/engine/plcnt.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
-#include "sf33rd/Source/Game/engine/cmb_win.h"
 #include "sf33rd/Source/Game/ui/count.h"
 #include "test/test_runner_utils.h"
 #include "types.h"
 
-#include <SDL3/SDL_endian.h>
-#include <SDL3/SDL_iostream.h>
-#include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL.h>
+
+#include <stdlib.h>
+
+#if _WIN32
+#include <intrin.h>
+#elif __APPLE__ || linux
+#include <signal.h>
+#endif
 
 typedef struct Position {
     s16 x;
     s16 y;
 } Position;
+
+static void stop_if(bool condition) {
+    if (!condition) {
+        return;
+    }
+
+    if (get_args()->statcheck.headless) {
+        exit(1);
+    } else {
+#if _WIN32
+        __debugbreak();
+#elif __APPLE__ || linux
+        raise(SIGSTOP);
+#endif
+    }
+}
 
 // Data reading
 

--- a/tools/fcade-replays/README.md
+++ b/tools/fcade-replays/README.md
@@ -54,6 +54,22 @@ python3 tools/fcade-replays/fcade_replay_tool.py bulk-download \
   --keep-going
 ```
 
+Convert a directory of downloaded replay folders into compressed RAM dumps:
+
+```bash
+python3 tools/replay_preprocessor.py \
+  tools/fcade-replays/output/bulk \
+  tools/fcade-replays/output/compressed \
+  --runner build/release/fbneosdlarm64
+```
+
+The wrapper runs each complete replay through the `--runner` executable, stores the
+runner's uncompressed `game_N` RAM dumps in a temporary directory, then writes
+`<replay-id>/game_N.scrd` under the requested output directory. Use `--runner` to
+select another executable, and `--game sfiii3nr1` when the replay folders do not
+have `summary.json` files. Each replay's temporary dumps are deleted before the
+next replay starts.
+
 ## Output Files
 
 Each output directory contains:

--- a/tools/fcade-replays/README.md
+++ b/tools/fcade-replays/README.md
@@ -1,5 +1,11 @@
 # Fightcade Replay Tool (WIP)
 
+Install Python dependencies for the helper scripts with:
+
+```bash
+python3 -m pip install -r tools/requirements-python.txt
+```
+
 `fcade_replay_tool.py` is a reverse-engineering helper for Fightcade replay streams.
 
 It supports:
@@ -69,6 +75,17 @@ runner's uncompressed `game_N` RAM dumps in a temporary directory, then writes
 select another executable, and `--game sfiii3nr1` when the replay folders do not
 have `summary.json` files. Each replay's temporary dumps are deleted before the
 next replay starts.
+
+Run statcheck against every preprocessed game archive:
+
+```bash
+python3 tools/statcheck_runner.py \
+  build-statcheck/3SX.app/Contents/MacOS/3SX \
+  tools/fcade-replays/output/compressed
+```
+
+The runner prints the result for each game and writes output from failed or crashed
+statcheck processes to a temporary report file whose path is printed at the end.
 
 ## Output Files
 

--- a/tools/fcade-replays/fcade_replay_tool.py
+++ b/tools/fcade-replays/fcade_replay_tool.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import socket
@@ -363,11 +364,17 @@ def download_replay(
             sock.settimeout(timeout)
     try:
         sock.connect((host, target.port))
-    except (TimeoutError, socket.timeout):
+    except OSError as exc:
         sock.close()
-        if local_port <= 0:
+        # A port that was available for bind() can still collide during connect()
+        # (for example, while a prior bulk-download connection is in TIME_WAIT).
+        # Retry with an OS-assigned source port in that case, just as we do after
+        # a timeout from the fixed Fightcade source port.
+        if local_port <= 0 or (
+            not isinstance(exc, socket.timeout) and exc.errno != errno.EADDRINUSE
+        ):
             raise
-        # Fallback: when repeatedly testing, forcing the same source port can time out.
+        # Fallback: forcing the Fightcade source port can time out or collide.
         used_local_port = 0
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(timeout)

--- a/tools/replay_preprocessor.py
+++ b/tools/replay_preprocessor.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Run Fightcade replays into temporary RAM dumps and package them as SCRD files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from compress_ram_dumps import compress_ram_dumps
+
+
+@dataclass
+class ReplayResult:
+    replay: str
+    status: str
+    game: str | None = None
+    archives: list[str] | None = None
+    error: str | None = None
+
+
+def find_replays(replay_root: Path) -> list[Path]:
+    if not replay_root.is_dir():
+        raise RuntimeError(f"replay directory is not a directory: {replay_root}")
+
+    return sorted(
+        path
+        for path in replay_root.iterdir()
+        if path.is_dir() and (path / "savestate").is_file() and (path / "inputs").is_file()
+    )
+
+
+def replay_game(replay_dir: Path, game_override: str | None) -> str:
+    if game_override:
+        return game_override
+
+    summary_path = replay_dir / "summary.json"
+    try:
+        summary: Any = json.loads(summary_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"missing {summary_path}; pass --game to set the game ID") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON in {summary_path}: {exc}") from exc
+
+    game = summary.get("game") if isinstance(summary, dict) else None
+    if not isinstance(game, str) or not game:
+        raise RuntimeError(f"missing game in {summary_path}; pass --game to set the game ID")
+    return game
+
+
+def game_dump_dirs(dump_root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in dump_root.iterdir()
+        if path.is_dir() and path.name.startswith("game_")
+    )
+
+
+def run_replay(
+    runner: Path,
+    replay_dir: Path,
+    game: str,
+    dump_root: Path,
+) -> None:
+    command = [
+        str(runner),
+        game,
+        "-replay-state",
+        str(replay_dir / "savestate"),
+        "-replay-inputs",
+        str(replay_dir / "inputs"),
+        "-headless",
+        "-dump-ram-path",
+        str(dump_root),
+    ]
+    subprocess.run(command, check=True)
+
+
+def process_replay(
+    runner: Path,
+    replay_dir: Path,
+    output_dir: Path,
+    game_override: str | None,
+    force: bool,
+    temp_root: Path,
+) -> ReplayResult:
+    game = replay_game(replay_dir, game_override)
+    dump_root = temp_root / replay_dir.name
+    dump_root.mkdir(parents=True)
+    run_replay(runner, replay_dir, game, dump_root)
+
+    dumps = game_dump_dirs(dump_root)
+    if not dumps:
+        raise RuntimeError("replay runner produced no game_N RAM-dump directories")
+
+    archives: list[str] = []
+    for dump_dir in dumps:
+        output_path = output_dir / replay_dir.name / f"{dump_dir.name}.scrd"
+        frame_count = compress_ram_dumps(dump_dir, output_path, force=force)
+        archives.append(str(output_path))
+        print(f"  wrote {output_path} ({frame_count} frames)")
+
+    return ReplayResult(replay=replay_dir.name, status="compressed", game=game, archives=archives)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("replay_dir", type=Path, help="directory containing replay subdirectories")
+    parser.add_argument("output_dir", type=Path, help="directory for <replay>/game_N.scrd archives")
+    parser.add_argument("--runner", type=Path, required=True, help="FBNeo replay runner executable")
+    parser.add_argument("--game", help="override the game ID instead of reading each summary.json")
+    parser.add_argument("-f", "--force", action="store_true", help="overwrite existing SCRD archives")
+    parser.add_argument("--fail-fast", action="store_true", help="stop at the first replay failure")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    runner = args.runner.resolve()
+    if not runner.is_file():
+        print(f"error: replay runner does not exist: {runner}", file=sys.stderr)
+        return 1
+    if not runner.stat().st_mode & 0o111:
+        print(f"error: replay runner is not executable: {runner}", file=sys.stderr)
+        return 1
+
+    try:
+        replays = find_replays(args.replay_dir)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if not replays:
+        print(f"error: no replay directories with both savestate and inputs under {args.replay_dir}", file=sys.stderr)
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    results: list[ReplayResult] = []
+    for index, replay_dir in enumerate(replays, start=1):
+        print(f"[{index}/{len(replays)}] {replay_dir.name}")
+        try:
+            # A replay can generate tens of gigabytes of raw frame dumps. Keep
+            # only one replay's dumps at a time, then delete them as soon as its
+            # game_N archives have been written.
+            with tempfile.TemporaryDirectory(prefix="fbneo-ram-dumps-") as temp_name:
+                result = process_replay(
+                    runner, replay_dir, args.output_dir, args.game, args.force, Path(temp_name)
+                )
+        except (OSError, RuntimeError, subprocess.CalledProcessError) as exc:
+            result = ReplayResult(replay=replay_dir.name, status="error", error=str(exc))
+            print(f"  error: {exc}", file=sys.stderr)
+            results.append(result)
+            if args.fail_fast:
+                break
+        else:
+            results.append(result)
+
+    manifest_path = args.output_dir / "bulk_ram_dump_manifest.json"
+    manifest_path.write_text(
+        json.dumps({"results": [asdict(result) for result in results]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    failed = sum(result.status == "error" for result in results)
+    print(f"wrote {manifest_path}; {len(results) - failed} compressed, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/requirements-python.txt
+++ b/tools/requirements-python.txt
@@ -1,0 +1,2 @@
+rich
+tqdm

--- a/tools/statcheck_runner.py
+++ b/tools/statcheck_runner.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Run a statcheck executable against every preprocessed replay game."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from rich.console import Console
+
+
+GAME_ARCHIVE_PATTERN = re.compile(r"game_(\d+)\.scrd$")
+console = Console()
+
+
+@dataclass(frozen=True)
+class GameArchive:
+    replay: str
+    game_index: int
+    path: Path
+
+
+def find_game_archives(replay_root: Path) -> list[GameArchive]:
+    if not replay_root.is_dir():
+        raise RuntimeError(f"preprocessed replay directory is not a directory: {replay_root}")
+
+    archives: list[GameArchive] = []
+    for replay_dir in sorted(path for path in replay_root.iterdir() if path.is_dir()):
+        for path in replay_dir.iterdir():
+            if not path.is_file():
+                continue
+            match = GAME_ARCHIVE_PATTERN.fullmatch(path.name)
+            if match:
+                archives.append(GameArchive(replay_dir.name, int(match.group(1)), path))
+
+    return sorted(archives, key=lambda archive: (archive.replay, archive.game_index))
+
+
+def return_code_description(return_code: int) -> str:
+    if return_code < 0:
+        return f"terminated by signal {-return_code}"
+    return f"exited with status {return_code}"
+
+
+def write_failure_report(
+    report,
+    archive: GameArchive,
+    command: list[str],
+    reason: str,
+    output: str,
+) -> None:
+    report.write(f"{'=' * 80}\n")
+    report.write(f"Replay: {archive.replay}\n")
+    report.write(f"Game: game_{archive.game_index}\n")
+    report.write(f"Archive: {archive.path}\n")
+    report.write(f"Command: {' '.join(command)}\n")
+    report.write(f"Result: {reason}\n")
+    report.write("Process output:\n")
+    report.write(output or "<no output>\n")
+    if output and not output.endswith("\n"):
+        report.write("\n")
+    report.flush()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("statcheck_executable", type=Path, help="statcheck executable")
+    parser.add_argument("replay_dir", type=Path, help="directory containing <replay>/game_N.scrd archives")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    executable = args.statcheck_executable.resolve()
+    if not executable.is_file():
+        print(f"error: statcheck executable does not exist: {executable}", file=sys.stderr)
+        return 1
+    if not executable.stat().st_mode & 0o111:
+        print(f"error: statcheck executable is not executable: {executable}", file=sys.stderr)
+        return 1
+
+    try:
+        archives = find_game_archives(args.replay_dir)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if not archives:
+        print(f"error: no game_N.scrd archives found under {args.replay_dir}", file=sys.stderr)
+        return 1
+
+    successes = 0
+    report = None
+    report_path = None
+    try:
+        for index, archive in enumerate(archives, start=1):
+            label = f"{archive.replay}/game_{archive.game_index}"
+            command = [str(executable), "--ram-archive", str(archive.path), "--headless"]
+            try:
+                result = subprocess.run(
+                    command,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    errors="replace",
+                )
+            except OSError as exc:
+                if report is None:
+                    report = tempfile.NamedTemporaryFile(
+                        mode="w", encoding="utf-8", prefix="statcheck-report-", suffix=".txt", delete=False
+                    )
+                    report_path = Path(report.name)
+                write_failure_report(report, archive, command, f"failed to start: {exc}", "")
+                console.print(f"[{index}/{len(archives)}] {label}: [red]✘[/red] (failed to start)")
+                continue
+
+            if result.returncode == 0:
+                successes += 1
+                console.print(f"[{index}/{len(archives)}] {label}: [green]✔[/green]")
+                continue
+
+            reason = return_code_description(result.returncode)
+            if report is None:
+                report = tempfile.NamedTemporaryFile(
+                    mode="w", encoding="utf-8", prefix="statcheck-report-", suffix=".txt", delete=False
+                )
+                report_path = Path(report.name)
+            write_failure_report(report, archive, command, reason, result.stdout)
+            console.print(f"[{index}/{len(archives)}] {label}: [red]✘[/red] ({reason})")
+    finally:
+        if report is not None:
+            report.close()
+
+    percentage = successes * 100 / len(archives)
+    print(f"{successes}/{len(archives)} successful ({percentage:.1f}%)")
+    if report_path is not None:
+        print(f"Failure report: {report_path}")
+    return 0 if successes == len(archives) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
- Added a replay preprocessing script. It allows turning raw replay data into SCRD archives in bulk
- Turned statcheck into a CMake option instead of a build configuration. This allows building Statcheck both in Debug and Release modes
- Added a statcheck runner script. It runs statcheck on multiple replays and reports aggregate results