### PR TITLE
Enable address sanitizer in Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,10 @@ if(NOT PSP AND (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STRE
 endif()
 
 if(PSP)
-    target_compile_options(3sx PRIVATE -G0)
+    target_compile_options(3sx PRIVATE
+        -G0
+        -Wno-format-truncation
+    )
     target_link_options(3sx PRIVATE -G0)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,16 @@ target_compile_options(3sx PRIVATE
     $<$<OR:$<CONFIG:Debug>,$<BOOL:${THREESX_STATCHECK}>>:-Wno-unused-but-set-variable>
 )
 
+if(NOT PSP AND (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL "GNU"))
+    target_compile_options(3sx PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
+        $<$<CONFIG:Debug>:-fno-omit-frame-pointer>
+    )
+    target_link_options(3sx PRIVATE
+        $<$<CONFIG:Debug>:-fsanitize=address>
+    )
+endif()
+
 if(PSP)
     target_compile_options(3sx PRIVATE -G0)
     target_link_options(3sx PRIVATE -G0)

--- a/src/sf33rd/AcrSDK/common/prilay.c
+++ b/src/sf33rd/AcrSDK/common/prilay.c
@@ -10,7 +10,8 @@ s8 plReportMessage[2048];
 s32 plReport(s8* format, ...) {
     va_list args;
     va_start(args, format);
-    vsprintf(plReportMessage, format, args);
+    vsnprintf(plReportMessage, sizeof(plReportMessage), format, args);
+    va_end(args);
     return 1;
 }
 

--- a/src/sf33rd/AcrSDK/ps2/flps2debug.c
+++ b/src/sf33rd/AcrSDK/ps2/flps2debug.c
@@ -34,7 +34,8 @@ s32 flPrintL(s32 posi_x, s32 posi_y, const char* format, ...) {
     buff_ptr += flDebugStrCtr;
 
     va_start(args, format);
-    vsprintf(str, format, args);
+    vsnprintf(str, sizeof(str), format, args);
+    va_end(args);
     len = strlen(str);
 
     if (flDebugStrCtr + len >= 0x12C0) {
@@ -85,7 +86,7 @@ void flPS2SystemError(s32 error_level, const char* format, ...) {
 
     flFlip(0);
     va_start(args, format);
-    vsprintf(str, format, args);
+    vsnprintf(str, sizeof(str), format, args);
     va_end(args);
     fatal_error("flps2debug: %s", str);
 }

--- a/src/sf33rd/AcrSDK/ps2/foundaps2.c
+++ b/src/sf33rd/AcrSDK/ps2/foundaps2.c
@@ -91,7 +91,7 @@ s32 flLogOut(const char* format, ...) {
 
     va_list args;
     va_start(args, format);
-    vsprintf(str, format, args);
+    vsnprintf(str, sizeof(str), format, args);
     va_end(args);
 
     fatal_error(str);

--- a/src/sf33rd/Source/PS2/mc/knjsub.c
+++ b/src/sf33rd/Source/PS2/mc/knjsub.c
@@ -542,7 +542,6 @@ static u32* get_img_adrs(_kanji_w* kw, u32 index) {
 }
 
 void KnjPrintf(const s8* fmt, ...) {
-    s8* p;
     s8 s[128];
     va_list args;
 
@@ -551,9 +550,8 @@ void KnjPrintf(const s8* fmt, ...) {
     }
 
     va_start(args, fmt);
-    p = s;
-    p += vsprintf(s, fmt, args);
-    *p = 0;
+    vsnprintf(s, sizeof(s), fmt, args);
+    va_end(args);
     KnjPuts(s);
 }
 

--- a/src/sf33rd/Source/PS2/mc/mcsub.c
+++ b/src/sf33rd/Source/PS2/mc/mcsub.c
@@ -555,7 +555,7 @@ static s32 mc_delete_dir(memcard_work* mw) {
         mw->cnt_1 = 0;
 
     block_8:
-        sprintf(mc_path, "%s/*", mw->path);
+        snprintf(mc_path, sizeof(mc_path), "%s/*", mw->path);
         mw->r_no_1 = 1;
 
     case 1:
@@ -589,12 +589,12 @@ static s32 mc_delete_dir(memcard_work* mw) {
             goto block_8;
         }
 
-        sprintf(mc_path, "%s/%s", mw->path, mc_dir.EntryName);
+        snprintf(mc_path, sizeof(mc_path), "%s/%s", mw->path, mc_dir.EntryName);
         mw->mode = 0;
         goto block_19;
 
     block_18:
-        sprintf(mc_path, "%s", mw->path);
+        snprintf(mc_path, sizeof(mc_path), "%s", mw->path);
         mw->mode = 1;
 
     block_19:
@@ -677,7 +677,7 @@ void McActInit(s32 file_type, s32 file_no) {
     strcpy(mw->dir, mf->file[4].name);
 
     if (mf->fnum_flag & 1) {
-        sprintf(tmp, "%02" PRId32, file_no);
+        snprintf(tmp, sizeof(tmp), "%02" PRId32, file_no);
         strcat(mw->dir, tmp);
     }
 }
@@ -736,11 +736,11 @@ void McActExistSet(s32 port, void* bufs) {
     mw->bufs = bufs;
 
     if (mf->file[5].flag == 0) {
-        sprintf(mw->path, "%s/%s", mw->dir, mw->dir);
+        snprintf(mw->path, sizeof(mw->path), "%s/%s", mw->dir, mw->dir);
         mw->size = mf->file[4].size;
         mw->mode = 0;
     } else {
-        sprintf(mw->path, "%s/%s", mw->dir, mf->file[5].name);
+        snprintf(mw->path, sizeof(mw->path), "%s/%s", mw->dir, mf->file[5].name);
         mw->size = mf->file[5].size;
         mw->mode = 1;
     }
@@ -858,7 +858,7 @@ void McActLoadSet(s32 port, void* bufs) {
     mw->r_no_1 = 0;
     mw->port = port;
     mw->bufs = bufs;
-    sprintf(mw->path, "%s/%s", mw->dir, mw->dir);
+    snprintf(mw->path, sizeof(mw->path), "%s/%s", mw->dir, mw->dir);
     mw->size = mf->file[4].size;
 }
 
@@ -936,7 +936,7 @@ void McActSave0Set(s32 port, void* bufs, s32 mode) {
     mw->port = port;
     mw->bufs = bufs;
     mw->mode = mode;
-    sprintf(mw->path, "%s/%s", mw->dir, mw->dir);
+    snprintf(mw->path, sizeof(mw->path), "%s/%s", mw->dir, mw->dir);
     mw->size = mf->file[4].size;
     memset(bufs, 0, mw->size);
 }
@@ -1053,7 +1053,7 @@ void McActSaveSet(s32 port, void* bufs) {
     mw->r_no_1 = 0;
     mw->cnt_0 = 0;
     mw->port = port;
-    sprintf(mw->path, "%s/%s", mw->dir, mw->dir);
+    snprintf(mw->path, sizeof(mw->path), "%s/%s", mw->dir, mw->dir);
     mw->size = mf->file[4].size;
     mf->file[4].bufs = (intptr_t)bufs;
     mf->file[5].bufs = (intptr_t)bufs + mw->size;
@@ -1078,7 +1078,7 @@ static void mc_act_save(memcard_work* mw) {
         case 2:
             mw->r_no_0 += 1;
             mc_icon_sys_set(mw);
-            sprintf(mw->path, "%s", mw->dir);
+            snprintf(mw->path, sizeof(mw->path), "%s", mw->dir);
             mw->copy = mf->copy_flag;
             break;
         }
@@ -1106,12 +1106,10 @@ static void mc_act_save(memcard_work* mw) {
             goto block_57;
         }
 
-        sprintf(mw->path, "%s/", mw->dir);
-
         if (mw->cnt_0 == 4) {
-            strcat(mw->path, mw->dir);
+            snprintf(mw->path, sizeof(mw->path), "%s/%s", mw->dir, mw->dir);
         } else {
-            strcat(mw->path, mf->file[mw->cnt_0].name);
+            snprintf(mw->path, sizeof(mw->path), "%s/%s", mw->dir, mf->file[mw->cnt_0].name);
         }
 
         mw->bufs = (void*)mf->file[mw->cnt_0].bufs;
@@ -1558,11 +1556,11 @@ static void mc_icon_sys_set(memcard_work* mw) {
 
     isys = (sceMcIconSys*)mf->file[0].bufs;
     isys->OffsLF = strlen(mf->title1);
-    sprintf((s8*)isys->TitleName, "%s%s", mf->title1, mf->title2);
-
     if (mf->fnum_flag & 2) {
         McActZenNum(mw->file_no, tmp, 1, 2);
-        strcat((s8*)isys->TitleName, tmp);
+        snprintf(isys->TitleName, sizeof(isys->TitleName), "%s%s%s", mf->title1, mf->title2, tmp);
+    } else {
+        snprintf(isys->TitleName, sizeof(isys->TitleName), "%s%s", mf->title1, mf->title2);
     }
 
     strcpy((s8*)isys->FnameView, mf->file[1].name);

--- a/src/sf33rd/Source/PS2/mc/savesub.c
+++ b/src/sf33rd/Source/PS2/mc/savesub.c
@@ -1334,7 +1334,7 @@ static void auto_load_set(_save_work* save) {
     } else {
         for (i = 0; i < 2; i++) {
             md = &save->auto_date[i];
-            sprintf(s[i], "%04d%02d%02d%02d%02d%02d", md->year, md->month, md->day, md->hour, md->min, md->sec);
+            snprintf(s[i], sizeof(s[i]), "%04d%02d%02d%02d%02d%02d", md->year, md->month, md->day, md->hour, md->min, md->sec);
         }
 
         save->sel_slot_no = (strcmp(s[0], s[1]) >= 0) ? 0 : 1;
@@ -1826,14 +1826,15 @@ static void self_order_get(_save_work* save) {
                 md[1] = (struct memcard_date*)&save->info[o[j]];
 
                 for (k = 0; k < 2; k++) {
-                    sprintf(s[k],
-                            "%04d%02d%02d%02d%02d%02d",
-                            md[k]->year,
-                            md[k]->month,
-                            md[k]->day,
-                            md[k]->hour,
-                            md[k]->min,
-                            md[k]->sec);
+                    snprintf(s[k],
+                             sizeof(s[k]),
+                             "%04d%02d%02d%02d%02d%02d",
+                             md[k]->year,
+                             md[k]->month,
+                             md[k]->day,
+                             md[k]->hour,
+                             md[k]->min,
+                             md[k]->sec);
                 }
 
                 if (strcmp(s[0], s[1]) < 0) {
@@ -2406,7 +2407,7 @@ static void save_msg_trans(_save_work* save) {
         y = 192;
         KnjLocate(x, y - 44);
         KnjPuts("MESSAGE No = ");
-        sprintf(tmp, "%" PRId32, no);
+        snprintf(tmp, sizeof(tmp), "%" PRId32, no);
         KnjSetColor(0x80008080);
         KnjPuts(tmp);
         KnjSetColor(0x80808080);
@@ -2451,7 +2452,7 @@ static void save_msg_trans(_save_work* save) {
             if (MsgLanguage == 0) {
                 McActZenNum(save->avail_size, tmp2, 0, 0);
             } else {
-                sprintf(tmp2, "%" PRId32, save->avail_size);
+                snprintf(tmp2, sizeof(tmp2), "%" PRId32, save->avail_size);
             }
 
             strcat(buf, tmp2);


### PR DESCRIPTION
Enabled address sanitizer in Debug builds to help with identifying memory-corruption-related bugs. I have found several such bugs already

Had to also port `sprintf`/`vsprintf` to safer alternatives