### PR TITLE
Fix rollback desyncs

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -26,6 +26,19 @@ static void verify_configuration(const Args* args) {
         error_out("Can't specify P2P and matchmaking at the same time.");
     }
 
+    if (netplay->stress && (p2p_specified || matchmaking_specified)) {
+        error_out("A stress session is local, so it can't be combined with P2P or matchmaking.");
+    }
+
+    if (!netplay->stress && (netplay->stress_seed != 0 || netplay->stress_check_distance != 0 ||
+                             netplay->stress_frames != 0 || netplay->stress_out != NULL)) {
+        error_out("Stress options require --stress.");
+    }
+
+    if (netplay->stress_check_distance < 0 || netplay->stress_frames < 0) {
+        error_out("Stress frame counts can't be negative.");
+    }
+
     if (p2p_specified) {
         if (netplay->p2p_local_player != 1 && netplay->p2p_local_player != 2) {
             error_out("Local player must be 1 or 2.");
@@ -68,6 +81,22 @@ void init_args(int argc, const char* argv[]) {
         OPT_STRING(0, "p2p-remote-ip", &args.netplay.p2p_remote_ip, "Remote player IP.", NULL, 0, 0),
         OPT_STRING(0, "matchmaking-ip", &args.netplay.matchmaking_ip, "Matchmaking server IP.", NULL, 0, 0),
         OPT_INTEGER(0, "matchmaking-port", &args.netplay.matchmaking_port, "Matchmaking server port.", NULL, 0, 0),
+        OPT_BOOLEAN(
+            0, "stress", &args.netplay.stress, "Run a local stress session that hunts for rollback desyncs.", NULL, 0, 0
+        ),
+        OPT_INTEGER(0, "stress-seed", &args.netplay.stress_seed, "Seed for the generated inputs.", NULL, 0, 0),
+        OPT_INTEGER(
+            0, "stress-check-distance", &args.netplay.stress_check_distance,
+            "How many frames to roll back and re-simulate each update.", NULL, 0, 0
+        ),
+        OPT_INTEGER(
+            0, "stress-frames", &args.netplay.stress_frames, "Exit after this many frames (0 runs until closed).", NULL,
+            0, 0
+        ),
+        OPT_STRING(
+            0, "stress-out", &args.netplay.stress_out,
+            "Directory for the trace and state dumps, so runs can go in parallel.", NULL, 0, 0
+        ),
 #endif
 
 #if STATCHECK

--- a/src/args.c
+++ b/src/args.c
@@ -86,16 +86,31 @@ void init_args(int argc, const char* argv[]) {
         ),
         OPT_INTEGER(0, "stress-seed", &args.netplay.stress_seed, "Seed for the generated inputs.", NULL, 0, 0),
         OPT_INTEGER(
-            0, "stress-check-distance", &args.netplay.stress_check_distance,
-            "How many frames to roll back and re-simulate each update.", NULL, 0, 0
+            0,
+            "stress-check-distance",
+            &args.netplay.stress_check_distance,
+            "How many frames to roll back and re-simulate each update.",
+            NULL,
+            0,
+            0
         ),
         OPT_INTEGER(
-            0, "stress-frames", &args.netplay.stress_frames, "Exit after this many frames (0 runs until closed).", NULL,
-            0, 0
+            0,
+            "stress-frames",
+            &args.netplay.stress_frames,
+            "Exit after this many frames (0 runs until closed).",
+            NULL,
+            0,
+            0
         ),
         OPT_STRING(
-            0, "stress-out", &args.netplay.stress_out,
-            "Directory for the trace and state dumps, so runs can go in parallel.", NULL, 0, 0
+            0,
+            "stress-out",
+            &args.netplay.stress_out,
+            "Directory for the trace and state dumps, so runs can go in parallel.",
+            NULL,
+            0,
+            0
         ),
 #endif
 

--- a/src/args.h
+++ b/src/args.h
@@ -9,6 +9,11 @@ typedef struct NetplayArgs {
     const char* p2p_remote_ip;
     const char* matchmaking_ip;
     int matchmaking_port;
+    bool stress;
+    int stress_seed;
+    int stress_check_distance;
+    int stress_frames;
+    const char* stress_out;
 } NetplayArgs;
 #endif
 

--- a/src/core/renderer.c
+++ b/src/core/renderer.c
@@ -15,10 +15,18 @@
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
 static bool skip_rendering() {
 #if STATCHECK
-    return get_args()->statcheck.headless;
-#else
-    return false;
+    if (get_args()->statcheck.headless) {
+        return true;
+    }
 #endif
+
+#if NETPLAY_ENABLED
+    if (get_args()->netplay.stress) {
+        return true;
+    }
+#endif
+
+    return false;
 }
 #endif
 

--- a/src/core/renderer.c
+++ b/src/core/renderer.c
@@ -15,18 +15,12 @@
 #if CRS_VIDEO_DRIVER_SDL_GENERIC
 static bool skip_rendering() {
 #if STATCHECK
-    if (get_args()->statcheck.headless) {
-        return true;
-    }
-#endif
-
-#if NETPLAY_ENABLED
-    if (get_args()->netplay.stress) {
-        return true;
-    }
-#endif
-
+    return get_args()->statcheck.headless;
+#elif NETPLAY_ENABLED
+    return get_args()->netplay.stress;
+#else
     return false;
+#endif
 }
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -262,6 +262,10 @@ void Main_StepFrame() {
     flPADGetALL();
     keyConvert();
 
+#if NETPLAY_ENABLED
+    Netplay_InjectStressBootInput();
+#endif
+
 #if DEBUG
     configure_slow_timer();
 #endif
@@ -298,6 +302,7 @@ void Main_StepFrame() {
         njdp2d_draw();
         Netplay_TickMatchmaking();
         Netplay_TickDirectP2P();
+        Netplay_TickStress();
     }
 #else
     njUserMain();

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 #include "common.h"
 #if NETPLAY_ENABLED
 #include "platform/netplay/netplay.h"
+#include "platform/netplay/netplay_stress.h"
 #endif
 #include "sf33rd/AcrSDK/common/mlPAD.h"
 #include "sf33rd/AcrSDK/ps2/flps2debug.h"
@@ -263,7 +264,7 @@ void Main_StepFrame() {
     keyConvert();
 
 #if NETPLAY_ENABLED
-    Netplay_InjectStressBootInput();
+    Stress_InjectBootInput();
 #endif
 
 #if DEBUG
@@ -302,7 +303,7 @@ void Main_StepFrame() {
         njdp2d_draw();
         Netplay_TickMatchmaking();
         Netplay_TickDirectP2P();
-        Netplay_TickStress();
+        Stress_Tick();
     }
 #else
     njUserMain();

--- a/src/platform/app/sdl/sdl_app.c
+++ b/src/platform/app/sdl/sdl_app.c
@@ -501,7 +501,10 @@ static int loop() {
 static void set_netplay_params() {
     const NetplayArgs* netplay = &get_args()->netplay;
 
-    if (netplay->p2p_remote_ip != NULL) {
+    if (netplay->stress) {
+        Netplay_SetStressOutputDir(netplay->stress_out);
+        Netplay_BeginStress(netplay->stress_seed, netplay->stress_check_distance, netplay->stress_frames);
+    } else if (netplay->p2p_remote_ip != NULL) {
         Netplay_SetParams(netplay->p2p_local_player, netplay->p2p_remote_ip);
     } else if (netplay->matchmaking_ip != NULL) {
         Netplay_SetMatchmakingParams(netplay->matchmaking_ip, netplay->matchmaking_port);

--- a/src/platform/app/sdl/sdl_app.c
+++ b/src/platform/app/sdl/sdl_app.c
@@ -18,6 +18,7 @@
 #endif
 
 #if NETPLAY_ENABLED
+#include "platform/app/sdl/sdl_stress_app.h"
 #include "platform/netplay/netplay.h"
 #include "port/sdl/netplay_screen.h"
 #include "port/sdl/netstats_renderer.h"
@@ -501,10 +502,7 @@ static int loop() {
 static void set_netplay_params() {
     const NetplayArgs* netplay = &get_args()->netplay;
 
-    if (netplay->stress) {
-        Netplay_SetStressOutputDir(netplay->stress_out);
-        Netplay_BeginStress(netplay->stress_seed, netplay->stress_check_distance, netplay->stress_frames);
-    } else if (netplay->p2p_remote_ip != NULL) {
+    if (netplay->p2p_remote_ip != NULL) {
         Netplay_SetParams(netplay->p2p_local_player, netplay->p2p_remote_ip);
     } else if (netplay->matchmaking_ip != NULL) {
         Netplay_SetMatchmakingParams(netplay->matchmaking_ip, netplay->matchmaking_port);
@@ -517,6 +515,10 @@ int main(int argc, const char* argv[]) {
 
 #if NETPLAY_ENABLED
     set_netplay_params();
+
+    if (get_args()->netplay.stress) {
+        return SDLStressApp_Run();
+    }
 #endif
 
 #if STATCHECK

--- a/src/platform/app/sdl/sdl_stress_app.c
+++ b/src/platform/app/sdl/sdl_stress_app.c
@@ -1,0 +1,63 @@
+#if CRS_APP_DRIVER_SDL && NETPLAY_ENABLED
+
+#include "platform/app/sdl/sdl_stress_app.h"
+#include "arcade/arcade_balance.h"
+#include "args.h"
+#include "main.h"
+#include "platform/netplay/netplay_stress.h"
+#include "port/config/config.h"
+#include "port/io/afs.h"
+#include "port/resources.h"
+
+#include <SDL3/SDL.h>
+
+#include <stdbool.h>
+
+static bool init() {
+    Config_Init();
+
+    if (!Resources_Check()) {
+        SDL_Log("Missing or invalid resources: %s", Resources_GetAFSPath());
+        return false;
+    }
+
+    ArcadeBalance_Init();
+
+    if (!AFS_Init(Resources_GetAFSPath(), 256 * 1024)) {
+        SDL_Log("Couldn't initialize AFS: %s", Resources_GetAFSPath());
+        return false;
+    }
+
+    Main_Init();
+    return true;
+}
+
+static void cleanup() {
+    AFS_Finish();
+    Config_Destroy();
+}
+
+int SDLStressApp_Run() {
+    const NetplayArgs* netplay = &get_args()->netplay;
+
+    Stress_SetOutputDir(netplay->stress_out);
+
+    if (!init()) {
+        Config_Destroy();
+        return 1;
+    }
+
+    Stress_Begin(netplay->stress_seed, netplay->stress_check_distance, netplay->stress_frames);
+
+    // No event loop to deliver a quit event, so the run ends on its own flag.
+    while (!Stress_IsFinished()) {
+        AFS_RunServer();
+        Main_StepFrame();
+        Main_FinishFrame();
+    }
+
+    cleanup();
+    return 0;
+}
+
+#endif // CRS_APP_DRIVER_SDL && NETPLAY_ENABLED

--- a/src/platform/app/sdl/sdl_stress_app.h
+++ b/src/platform/app/sdl/sdl_stress_app.h
@@ -1,0 +1,6 @@
+#ifndef SDL_STRESS_APP_H
+#define SDL_STRESS_APP_H
+
+int SDLStressApp_Run();
+
+#endif

--- a/src/platform/netplay/game_state.c
+++ b/src/platform/netplay/game_state.c
@@ -471,7 +471,8 @@ void GameState_Save(GameState* dst) {
     GS_SAVE(Random_ix32_com);
     GS_SAVE(Random_ix16_ex_com);
     GS_SAVE(Random_ix32_ex_com);
-    GS_SAVE(Random_ix16_bg);
+    // Random_ix16_bg is left out on purpose: it only drives stage flashing, and the
+    // state deciding when to draw from it isn't saved.
     GS_SAVE(Opening_Now);
     GS_SAVE(task);
 
@@ -1099,7 +1100,6 @@ void GameState_Load(const GameState* src) {
     GS_LOAD(Random_ix32_com);
     GS_LOAD(Random_ix16_ex_com);
     GS_LOAD(Random_ix32_ex_com);
-    GS_LOAD(Random_ix16_bg);
     GS_LOAD(Opening_Now);
     GS_LOAD(task);
 

--- a/src/platform/netplay/game_state.c
+++ b/src/platform/netplay/game_state.c
@@ -457,8 +457,9 @@ void GameState_Save(GameState* dst) {
     GS_SAVE(Cont_Timer);
     GS_SAVE(Plate_X);
     GS_SAVE(Plate_Y);
-    // GS_SAVE(Demo_Timer);
-    // GS_SAVE(Condense_Buff);
+    GS_SAVE(Demo_Timer);
+    GS_SAVE(Condense_Buff);
+    GS_SAVE(Demo_Ptr);
     GS_SAVE(Keep_Grade);
     GS_SAVE(IO_Result);
     GS_SAVE(VS_Win_Record);
@@ -1086,8 +1087,9 @@ void GameState_Load(const GameState* src) {
     GS_LOAD(Cont_Timer);
     GS_LOAD(Plate_X);
     GS_LOAD(Plate_Y);
-    // GS_LOAD(Demo_Timer);
-    // GS_LOAD(Condense_Buff);
+    GS_LOAD(Demo_Timer);
+    GS_LOAD(Condense_Buff);
+    GS_LOAD(Demo_Ptr);
     GS_LOAD(Keep_Grade);
     GS_LOAD(IO_Result);
     GS_LOAD(VS_Win_Record);

--- a/src/platform/netplay/game_state.c
+++ b/src/platform/netplay/game_state.c
@@ -17,7 +17,13 @@
 
 #include <SDL3/SDL.h>
 
-#define GS_SAVE(member) SDL_memcpy(&dst->member, &member, sizeof(member))
+// Copies are sized by the global, so a mismatched field would spill into its neighbours.
+#define GS_ASSERT_SAME_SIZE(member)                                                                                    \
+    _Static_assert(sizeof(((GameState*)0)->member) == sizeof(member), #member " does not match its global")
+
+#define GS_SAVE(member)                                                                                                \
+    GS_ASSERT_SAME_SIZE(member);                                                                                       \
+    SDL_memcpy(&dst->member, &member, sizeof(member))
 
 void GameState_Save(GameState* dst) {
     GS_SAVE(Scene_Cut);
@@ -642,7 +648,9 @@ void GameState_Save(GameState* dst) {
     GS_SAVE(mes_timer);
 }
 
-#define GS_LOAD(member) SDL_memcpy(&member, &src->member, sizeof(member))
+#define GS_LOAD(member)                                                                                                \
+    GS_ASSERT_SAME_SIZE(member);                                                                                       \
+    SDL_memcpy(&member, &src->member, sizeof(member))
 
 void GameState_Load(const GameState* src) {
     GS_LOAD(Scene_Cut);

--- a/src/platform/netplay/game_state.c
+++ b/src/platform/netplay/game_state.c
@@ -2,6 +2,7 @@
 #include "sf33rd/Source/Game/animation/appear.h"
 #include "sf33rd/Source/Game/animation/win_pl.h"
 #include "sf33rd/Source/Game/effect/eff56.h"
+#include "sf33rd/Source/Game/effect/eff79.h"
 #include "sf33rd/Source/Game/effect/effb2.h"
 #include "sf33rd/Source/Game/effect/effb8.h"
 #include "sf33rd/Source/Game/engine/charset.h"
@@ -245,6 +246,8 @@ void GameState_Save(GameState* dst) {
     GS_SAVE(Plate_Disposal_No);
     GS_SAVE(SO_No);
     GS_SAVE(Disp_Command_Name);
+    GS_SAVE(OK_Appear79);
+    GS_SAVE(Extra_Counter);
     GS_SAVE(SC_No);
     GS_SAVE(BGM_No);
     GS_SAVE(BGM_Timer);
@@ -875,6 +878,8 @@ void GameState_Load(const GameState* src) {
     GS_LOAD(Plate_Disposal_No);
     GS_LOAD(SO_No);
     GS_LOAD(Disp_Command_Name);
+    GS_LOAD(OK_Appear79);
+    GS_LOAD(Extra_Counter);
     GS_LOAD(SC_No);
     GS_LOAD(BGM_No);
     GS_LOAD(BGM_Timer);

--- a/src/platform/netplay/game_state.c
+++ b/src/platform/netplay/game_state.c
@@ -11,6 +11,7 @@
 #include "sf33rd/Source/Game/engine/workuser.h"
 #include "sf33rd/Source/Game/stage/bg_data.h"
 #include "sf33rd/Source/Game/stage/ta_sub.h"
+#include "sf33rd/Source/Game/system/sysdir.h"
 #include "sf33rd/Source/Game/system/work_sys.h"
 #include "sf33rd/Source/Game/ui/count.h"
 #include "sf33rd/Source/Game/ui/sc_sub.h"
@@ -511,6 +512,7 @@ void GameState_Save(GameState* dst) {
     GS_SAVE(bonus_pts);
     GS_SAVE(hit_num);
     GS_SAVE(sa_kind);
+    GS_SAVE(chainex_check);
     GS_SAVE(end_flag);
     GS_SAVE(calc_hit);
     GS_SAVE(score_calc);
@@ -1138,6 +1140,7 @@ void GameState_Load(const GameState* src) {
     GS_LOAD(bonus_pts);
     GS_LOAD(hit_num);
     GS_LOAD(sa_kind);
+    GS_LOAD(chainex_check);
     GS_LOAD(end_flag);
     GS_LOAD(calc_hit);
     GS_LOAD(score_calc);

--- a/src/platform/netplay/game_state.h
+++ b/src/platform/netplay/game_state.h
@@ -447,6 +447,7 @@ typedef struct GameState {
     s16 Plate_X[2][3];
     s16 Plate_Y[2][3];
     u16 Demo_Timer[2];
+    u16* Demo_Ptr[2]; // the recorder appends through this, so it has to rewind too
     u16 Condense_Buff[2];
     u16 Keep_Grade[2];
     u16 IO_Result;

--- a/src/platform/netplay/game_state.h
+++ b/src/platform/netplay/game_state.h
@@ -234,6 +234,8 @@ typedef struct GameState {
     u8 Plate_Disposal_No[2][3];
     u8 SO_No[2];
     u8 Disp_Command_Name[2][3];
+    u8 OK_Appear79[2];
+    u8 Extra_Counter[2];
     u8 SC_No[4];
     u8 BGM_No[2];
     u8 BGM_Timer[2];

--- a/src/platform/netplay/game_state.h
+++ b/src/platform/netplay/game_state.h
@@ -501,6 +501,7 @@ typedef struct GameState {
     s8 bonus_pts[2];
     s16 hit_num;
     u8 sa_kind;
+    u8 chainex_check[2][36];
     u8 end_flag[2];
     s16 calc_hit[2][10];
     s16 score_calc[2][12];

--- a/src/platform/netplay/game_state.h
+++ b/src/platform/netplay/game_state.h
@@ -322,7 +322,7 @@ typedef struct GameState {
     s8 Menu_Max;
     u8 reset_NG_flag;
     s8 VS_Stage;
-    PresentMode Present_Mode; // must match the global: the copies are sized by it
+    PresentMode Present_Mode;
     u8 Play_Mode;
     u8 Page_Max;
     u8 Direction_Working[6];

--- a/src/platform/netplay/game_state.h
+++ b/src/platform/netplay/game_state.h
@@ -460,7 +460,6 @@ typedef struct GameState {
     s16 Random_ix32_com;
     s16 Random_ix16_ex_com;
     s16 Random_ix32_ex_com;
-    s16 Random_ix16_bg;
     s16 Opening_Now;
     struct _TASK task[11];
 

--- a/src/platform/netplay/game_state.h
+++ b/src/platform/netplay/game_state.h
@@ -322,7 +322,7 @@ typedef struct GameState {
     s8 Menu_Max;
     u8 reset_NG_flag;
     s8 VS_Stage;
-    u8 Present_Mode;
+    PresentMode Present_Mode; // must match the global: the copies are sized by it
     u8 Play_Mode;
     u8 Page_Max;
     u8 Direction_Working[6];

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -5,6 +5,8 @@
 #include "platform/app/sdl/sdl_app.h"
 #include "platform/netplay/fistbump.h"
 #include "platform/netplay/game_state.h"
+#include "platform/netplay/netplay_base.h"
+#include "platform/netplay/netplay_stress.h"
 #include "platform/netplay/sdl_net_adapter.h"
 #include "port/paths.h"
 #include "sf33rd/AcrSDK/common/pad.h"
@@ -32,35 +34,15 @@
 #include <SDL3/SDL.h>
 #include <SDL3_net/SDL_net.h>
 
-#include <stdarg.h>
 #include <stdlib.h>
 
 #define INPUT_HISTORY_MAX 120
-#define STRESS_CHECK_DISTANCE_DEFAULT 8
-#define GAME_STATE_FIGHT 2      // G_No[1] while a round is being played
-#define STRESS_PAD_CONNECTED 2  // Interface_Type value keyConvert() uses for a present pad
 #define FRAME_SKIP_TIMER_MAX 60 // Allow skipping a frame roughly every second
 #define STATS_UPDATE_TIMER_MAX 60
 #define DELAY_FRAMES 1
-#define PLAYER_COUNT 2
 
 // Uncomment to enable packet drops
 // #define LOSSY_ADAPTER
-
-typedef struct EffectState {
-    s16 frwctr;
-    s16 frwctr_min;
-    s16 head_ix[8];
-    s16 tail_ix[8];
-    s16 exec_tm[8];
-    uintptr_t frw[EFFECT_MAX][448];
-    s16 frwque[EFFECT_MAX];
-} EffectState;
-
-typedef struct State {
-    GameState gs;
-    EffectState es;
-} State;
 
 static GekkoSession* session = NULL;
 static unsigned short local_port = 0;
@@ -75,16 +57,6 @@ static int matchmaking_server_port = 9000;
 static bool matchmaking_pending = false;
 static bool direct_p2p_configured = false;
 static bool direct_p2p_pending = false;
-static bool stress_pending = false;
-static bool stress_mode = false;
-static u32 stress_rng = 0;
-static int stress_check_distance = 0;
-static int stress_frame_limit = 0;
-static int stress_frames_run = 0;
-static int stress_desyncs = 0;
-static int stress_boot_timer = 0;
-static bool stress_waiting_for_match = false;
-static const char* stress_out_dir = ".";
 static NET_DatagramSocket* p2p_sock = NULL;
 static u16 input_history[2][INPUT_HISTORY_MAX] = { 0 };
 static float frames_behind = 0;
@@ -96,7 +68,6 @@ static int frame_max_rollback = 0;
 static NetworkStats network_stats = { 0 };
 
 #if DEBUG
-#define STATE_BUFFER_MAX 20
 #define STATE_SLOT_EMPTY (-1)
 
 static State state_buffer[STATE_BUFFER_MAX] = { 0 };
@@ -107,16 +78,11 @@ static State resim_state_buffer[STATE_BUFFER_MAX] = { 0 };
 static int resim_state_buffer_frame[STATE_BUFFER_MAX] = { 0 };
 static u32 state_buffer_checksum[STATE_BUFFER_MAX] = { 0 };
 
-// Only the first re-simulation that disagrees is worth keeping.
-static bool stress_pair_dumped = false;
-
 static void reset_state_buffers() {
     for (int i = 0; i < STATE_BUFFER_MAX; i++) {
         state_buffer_frame[i] = STATE_SLOT_EMPTY;
         resim_state_buffer_frame[i] = STATE_SLOT_EMPTY;
     }
-
-    stress_pair_dumped = false;
 }
 
 static int state_slot(int frame) {
@@ -160,7 +126,7 @@ static void clean_input_buffers() {
     SDL_zeroa(plsw_01);
 }
 
-static void setup_vs_mode() {
+void NetplayBase_SetupVsMode() {
     task[TASK_MENU].r_no[0] = 5; // go to idle routine (doing nothing)
     cpExitTask(TASK_SAVER);
 
@@ -215,102 +181,6 @@ static void configure_lossy_adapter(NET_DatagramSocket* sock) {
 }
 #endif
 
-/// Builds a path inside the run's output directory, so parallel runs stay separate.
-static void stress_path(char* dst, size_t size, const char* relative) {
-    SDL_snprintf(dst, size, "%s/%s", stress_out_dir, relative);
-}
-
-/// Appends to stress-trace.log. A stress run is unattended, so the trace has to
-/// survive however the game was launched.
-static void stress_trace(const char* fmt, ...) {
-    char path[512];
-    stress_path(path, sizeof(path), "stress-trace.log");
-
-    SDL_IOStream* io = SDL_IOFromFile(path, "a");
-
-    if (io == NULL) {
-        return;
-    }
-
-    va_list args;
-    va_start(args, fmt);
-    SDL_IOvprintf(io, fmt, args);
-    va_end(args);
-
-    SDL_IOprintf(io, "\n");
-    SDL_CloseIO(io);
-}
-
-static u32 stress_random() {
-    // xorshift32, so a seed reproduces the exact same run.
-    stress_rng ^= stress_rng << 13;
-    stress_rng ^= stress_rng >> 17;
-    stress_rng ^= stress_rng << 5;
-    return stress_rng;
-}
-
-/// Holds presses for a few frames at a time, which exercises moves and cancels
-/// rather than one-frame noise.
-static u16 stress_random_input(int player) {
-    static const u16 directions[] = { 0,
-                                      SWK_UP,
-                                      SWK_DOWN,
-                                      SWK_LEFT,
-                                      SWK_RIGHT,
-                                      SWK_UP | SWK_LEFT,
-                                      SWK_UP | SWK_RIGHT,
-                                      SWK_DOWN | SWK_LEFT,
-                                      SWK_DOWN | SWK_RIGHT };
-
-    static const u16 attacks[] = { SWK_WEST,          SWK_NORTH, SWK_RIGHT_SHOULDER,
-                                   SWK_LEFT_SHOULDER, SWK_SOUTH, SWK_RIGHT_TRIGGER };
-
-    static u16 held[2] = { 0, 0 };
-    static int hold_frames[2] = { 0, 0 };
-
-    if (hold_frames[player] > 0) {
-        hold_frames[player] -= 1;
-        return held[player];
-    }
-
-    u16 input = directions[stress_random() % SDL_arraysize(directions)];
-
-    // Roughly a third of the time, press an attack alongside the direction.
-    if (stress_random() % 3 == 0) {
-        input |= attacks[stress_random() % SDL_arraysize(attacks)];
-    }
-
-    held[player] = input;
-    hold_frames[player] = (int)(stress_random() % 6);
-
-    return input;
-}
-
-static void configure_stress_session(GekkoConfig* config) {
-    config->check_distance = stress_check_distance;
-
-    if (!gekko_create(&session, GekkoStressSession)) {
-        SDL_Log("Session is already running! probably incorrect.");
-        return;
-    }
-
-    gekko_start(session, config);
-
-    // A stress session simulates both sides locally, so both actors are local.
-    for (int i = 0; i < PLAYER_COUNT; i++) {
-        gekko_add_actor(session, GekkoLocalPlayer, NULL);
-    }
-
-    player_handle = 0;
-
-    stress_trace(
-        "session created (seed %u, check distance %d, frame limit %d)",
-        stress_rng,
-        stress_check_distance,
-        stress_frame_limit
-    );
-}
-
 static void configure_gekko() {
     GekkoConfig config;
     SDL_zero(config);
@@ -326,8 +196,8 @@ static void configure_gekko() {
     reset_state_buffers();
 #endif
 
-    if (stress_mode) {
-        configure_stress_session(&config);
+    if (Stress_IsRunning()) {
+        Stress_CreateSession(&config, &session, &player_handle);
         return;
     }
 
@@ -518,11 +388,11 @@ static const State* note_state(const State* state, int frame) {
 
 static void dump_state(const State* src, const char* relative) {
     char states_dir[512];
-    stress_path(states_dir, sizeof(states_dir), "states");
+    Stress_Path(states_dir, sizeof(states_dir), "states");
     SDL_CreateDirectory(states_dir);
 
     char filename[512];
-    stress_path(filename, sizeof(filename), relative);
+    Stress_Path(filename, sizeof(filename), relative);
 
     SDL_IOStream* io = SDL_IOFromFile(filename, "w");
 
@@ -554,8 +424,7 @@ static void dump_saved_state(int frame) {
     dump_state(src, filename);
 }
 
-/// Dump both simulations of a frame so compare_states.py can diff them as a pair.
-static void dump_desync_pair(int frame) {
+void NetplayBase_DumpDesyncPair(int frame) {
     const int slot = frame % STATE_BUFFER_MAX;
 
     if (state_buffer_frame[slot] != frame || resim_state_buffer_frame[slot] != frame) {
@@ -611,13 +480,8 @@ static void save_state(GekkoGameEvent* event) {
 
     if (!is_resimulation) {
         state_buffer_checksum[slot] = checksum;
-    } else if (stress_mode && !stress_pair_dumped && checksum != state_buffer_checksum[slot]) {
-        // Catch the divergence here rather than when the session reports it:
-        // by then this frame has been re-simulated several more times and the
-        // buffer may hold a pass that happens to agree.
-        stress_pair_dumped = true;
-        dump_desync_pair(frame);
-        stress_trace("re-simulation of frame %d diverged (0x%X vs 0x%X)", frame, state_buffer_checksum[slot], checksum);
+    } else if (Stress_IsRunning() && checksum != state_buffer_checksum[slot]) {
+        Stress_OnResimulationDiverged(frame, state_buffer_checksum[slot], checksum);
     }
 #endif
 }
@@ -647,7 +511,7 @@ static void load_state_from_event(GekkoGameEvent* event) {
     // that was loaded. Anything that differs is state the save/load pair drops.
     static bool round_trip_checked = false;
 
-    if (stress_mode && !round_trip_checked) {
+    if (Stress_IsRunning() && !round_trip_checked) {
         round_trip_checked = true;
 
         static State before;
@@ -662,7 +526,7 @@ static void load_state_from_event(GekkoGameEvent* event) {
         dump_state(&before, "states/0_9999");
         dump_state(&after, "states/1_9999");
 
-        stress_trace("round-trip dump written for frame %d", event->data.load.frame);
+        Stress_Trace("round-trip dump written for frame %d", event->data.load.frame);
     }
 #endif
 }
@@ -714,9 +578,9 @@ static void process_session() {
 
     gekko_network_poll(session);
 
-    if (stress_mode) {
+    if (Stress_IsRunning()) {
         for (int i = 0; i < PLAYER_COUNT; i++) {
-            u16 stress_inputs = stress_random_input(i);
+            u16 stress_inputs = Stress_NextInput(i);
             gekko_add_local_input(session, i, &stress_inputs);
         }
     } else {
@@ -760,20 +624,8 @@ static void process_session() {
             );
 
 #if DEBUG
-            if (stress_mode) {
-                stress_desyncs += 1;
-                stress_trace("desync at frame %d after %d frames", frame, stress_frames_run);
-
-                if (!stress_pair_dumped) {
-                    // The divergence was outside the window save_state watches.
-                    stress_pair_dumped = true;
-                    dump_desync_pair(frame);
-                }
-
-                // Finding one is the whole point of the run, so stop here and
-                // leave the dumps for compare_states.py.
-                stress_trace("exiting: desync found after %d frames", stress_frames_run);
-                SDLApp_Exit();
+            if (Stress_IsRunning()) {
+                Stress_OnDesync(frame);
             } else {
                 dump_saved_state(frame);
             }
@@ -808,12 +660,8 @@ static void process_events(bool drawing_allowed) {
             advance_game(event, drawing_allowed && !rolling_back);
             frames_rolled_back += rolling_back ? 1 : 0;
 
-            if (stress_mode && !rolling_back) {
-                stress_frames_run += 1;
-
-                if (stress_frames_run % 60 == 0) {
-                    stress_trace("stress frame %d (%d desync(s))", stress_frames_run, stress_desyncs);
-                }
+            if (Stress_IsRunning() && !rolling_back) {
+                Stress_OnFrameAdvanced();
             }
             break;
 
@@ -919,7 +767,7 @@ void Netplay_TickDirectP2P() {
     }
 
     direct_p2p_pending = false;
-    setup_vs_mode();
+    NetplayBase_SetupVsMode();
 
     SDL_zeroa(input_history);
     frames_behind = 0;
@@ -929,145 +777,13 @@ void Netplay_TickDirectP2P() {
     session_state = NETPLAY_SESSION_TRANSITIONING;
 }
 
-void Netplay_SetStressOutputDir(const char* directory) {
-    if (directory != NULL) {
-        stress_out_dir = directory;
-    }
-}
-
-void Netplay_BeginStress(int seed, int check_distance, int frames) {
-    // A zero seed would make xorshift produce nothing but zeroes.
-    stress_rng = seed != 0 ? (u32)seed : 1;
-
-    stress_check_distance = check_distance > 0 ? check_distance : STRESS_CHECK_DISTANCE_DEFAULT;
-    stress_frame_limit = frames;
-    stress_pending = true;
-
-#if DEBUG
-    // Both simulations of a frame have to still be in the buffer when the desync
-    // is reported, which is check_distance frames after the fact.
-    if (stress_check_distance >= STATE_BUFFER_MAX) {
-        stress_check_distance = STATE_BUFFER_MAX - 1;
-        SDL_Log("Clamped stress check distance to %d.", stress_check_distance);
-    }
-#endif
-}
-
-static bool game_is_in_a_fight() {
-    return G_No[1] == GAME_STATE_FIGHT;
-}
-
-/// A stress run is unattended, so it drives the boot screens and character
-/// select itself. Called after keyConvert() has filled the pad buffers, and only
-/// until the session takes over the inputs.
-void Netplay_InjectStressBootInput() {
-    if (!stress_pending && !stress_waiting_for_match && !stress_mode) {
-        return;
-    }
-
-    // Both players are simulated, but only port 1 has real hardware behind it.
-    // keyConvert() clears the other port every frame, which makes the game ask
-    // for a controller to be reconnected mid-match.
-    Interface_Type[0] = STRESS_PAD_CONNECTED;
-    Interface_Type[1] = STRESS_PAD_CONNECTED;
-
-    if (stress_mode) {
-        // The session drives the inputs once it is running.
-        return;
-    }
-
-    stress_boot_timer += 1;
-
-    if (stress_boot_timer % 60 == 0) {
-        stress_trace(
-            "driving menus, frame %d: menu cond %d, G_No %d/%d/%d",
-            stress_boot_timer,
-            task[TASK_MENU].condition,
-            G_No[0],
-            G_No[1],
-            G_No[2]
-        );
-    }
-
-    if (stress_pending) {
-        // Tap rather than hold: the screens react to a press, not to the button
-        // being down, and holding it would only ever produce one edge.
-        if ((stress_boot_timer / 4) % 2 == 0) {
-            p1sw_buff |= SWK_START;
-        }
-
-        return;
-    }
-
-    // Character select and the screens around it. Both sides need to pick, so
-    // feed both pads and tap start to get through the VS screens.
-    p1sw_buff |= stress_random_input(0);
-    p2sw_buff |= stress_random_input(1);
-
-    if ((stress_boot_timer / 8) % 2 == 0) {
-        p1sw_buff |= SWK_START;
-        p2sw_buff |= SWK_START;
-    }
-}
-
-void Netplay_TickStress() {
-    if (stress_pending) {
-        // Wait for the game to reach the menus before taking it into VS mode.
-        if (task[TASK_MENU].condition != 1) {
-            return;
-        }
-
-        stress_trace("entering versus mode from G_No %d/%d/%d", G_No[0], G_No[1], G_No[2]);
-
-        stress_pending = false;
-        stress_waiting_for_match = true;
-        setup_vs_mode();
-
-        // Character select is driven by the pads, not by the session, so run it
-        // as a local versus match.
-        Mode_Type = MODE_VERSUS;
-        return;
-    }
-
-    if (!stress_waiting_for_match || !game_is_in_a_fight()) {
-        return;
-    }
-
-    // The fight is running, so hand the simulation over to the stress session.
-    // Starting here keeps the rollback away from character select and stage
-    // loading, which are far too expensive to re-simulate every frame.
-    stress_trace("fight reached, creating session at G_No %d/%d/%d", G_No[0], G_No[1], G_No[2]);
-
-    stress_waiting_for_match = false;
-    stress_mode = true;
-
-    const int previous_operators[PLAYER_COUNT] = { plw[0].wu.operator, plw[1].wu.operator };
-
-    // Both sides have to read their lever from the session. A CPU-controlled
-    // player derives it from cpu_algorithm() instead, whose state isn't part of
-    // the saved State, so it would diverge on every rollback.
-    for (int i = 0; i < PLAYER_COUNT; i++) {
-        Operator_Status[i] = 1;
-        plw[i].wu.operator = 1;
-    }
-
-    stress_trace("operators were %d/%d, forced to human", previous_operators[0], previous_operators[1]);
-
+void NetplayBase_StartStressSession() {
     SDL_zeroa(input_history);
     frames_behind = 0;
     frame_skip_timer = 0;
 
     configure_gekko();
     session_state = NETPLAY_SESSION_RUNNING;
-}
-
-static void check_stress_frame_limit() {
-    if (!stress_mode || stress_frame_limit <= 0 || stress_frames_run < stress_frame_limit) {
-        return;
-    }
-
-    stress_trace("exiting: frame limit reached after %d frames, %d desync(s)", stress_frames_run, stress_desyncs);
-    SDLApp_Exit();
 }
 
 void Netplay_SetMatchmakingParams(const char* server_ip, int server_port) {
@@ -1105,7 +821,7 @@ void Netplay_TickMatchmaking() {
         frame_skip_timer = 0;
         transition_ready_frames = 0;
         matchmaking_pending = false;
-        setup_vs_mode();
+        NetplayBase_SetupVsMode();
         session_state = NETPLAY_SESSION_TRANSITIONING;
     } else if (mm == FISTBUMP_ERROR) {
         matchmaking_pending = false;
@@ -1138,16 +854,6 @@ void Netplay_CancelMatchmaking() {
 void Netplay_Run() {
     switch (session_state) {
     case NETPLAY_SESSION_TRANSITIONING:
-        if (stress_mode) {
-            static int transition_trace = 0;
-
-            if (transition_trace++ % 60 == 0) {
-                stress_trace(
-                    "transitioning: G_No %d/%d/%d, ready %d", G_No[0], G_No[1], G_No[2], transition_ready_frames
-                );
-            }
-        }
-
         if (game_ready_to_run_character_select()) {
             transition_ready_frames += 1;
         } else {
@@ -1158,9 +864,7 @@ void Netplay_Run() {
 
         if (transition_ready_frames >= 2) {
             configure_gekko();
-            // A stress session is local, so there is no handshake to wait for
-            // and no GekkoSessionStarted event will ever arrive.
-            session_state = stress_mode ? NETPLAY_SESSION_RUNNING : NETPLAY_SESSION_CONNECTING;
+            session_state = NETPLAY_SESSION_CONNECTING;
         }
 
         break;
@@ -1168,7 +872,6 @@ void Netplay_Run() {
     case NETPLAY_SESSION_CONNECTING:
     case NETPLAY_SESSION_RUNNING:
         run_netplay();
-        check_stress_frame_limit();
         break;
 
     case NETPLAY_SESSION_EXITING:

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -38,8 +38,8 @@
 
 #define INPUT_HISTORY_MAX 120
 #define STRESS_CHECK_DISTANCE_DEFAULT 8
-#define GAME_STATE_FIGHT 2 // G_No[1] while a round is being played
-#define STRESS_PAD_CONNECTED 2 // Interface_Type value keyConvert() uses for a present pad
+#define GAME_STATE_FIGHT 2      // G_No[1] while a round is being played
+#define STRESS_PAD_CONNECTED 2  // Interface_Type value keyConvert() uses for a present pad
 #define FRAME_SKIP_TIMER_MAX 60 // Allow skipping a frame roughly every second
 #define STATS_UPDATE_TIMER_MAX 60
 #define DELAY_FRAMES 1
@@ -263,8 +263,8 @@ static u16 stress_random_input(int player) {
                                       SWK_DOWN | SWK_LEFT,
                                       SWK_DOWN | SWK_RIGHT };
 
-    static const u16 attacks[] = { SWK_WEST,  SWK_NORTH,          SWK_RIGHT_SHOULDER, SWK_LEFT_SHOULDER,
-                                   SWK_SOUTH, SWK_RIGHT_TRIGGER };
+    static const u16 attacks[] = { SWK_WEST,          SWK_NORTH, SWK_RIGHT_SHOULDER,
+                                   SWK_LEFT_SHOULDER, SWK_SOUTH, SWK_RIGHT_TRIGGER };
 
     static u16 held[2] = { 0, 0 };
     static int hold_frames[2] = { 0, 0 };
@@ -305,7 +305,9 @@ static void configure_stress_session(GekkoConfig* config) {
     player_handle = 0;
 
     stress_trace(
-        "session created (seed %u, check distance %d, frame limit %d)", stress_rng, stress_check_distance,
+        "session created (seed %u, check distance %d, frame limit %d)",
+        stress_rng,
+        stress_check_distance,
         stress_frame_limit
     );
 }
@@ -546,8 +548,7 @@ static void dump_saved_state(int frame) {
     }
 
     // The re-simulated state is the one the session ended up agreeing on.
-    const State* src =
-        resim_state_buffer_frame[slot] == frame ? &resim_state_buffer[slot] : &state_buffer[slot];
+    const State* src = resim_state_buffer_frame[slot] == frame ? &resim_state_buffer[slot] : &state_buffer[slot];
 
     char filename[100];
     SDL_snprintf(filename, sizeof(filename), "states/%d_%d", player_handle, frame);
@@ -689,7 +690,6 @@ static void advance_game(GekkoGameEvent* event, bool render) {
     const u16* inputs = (u16*)event->data.adv.inputs;
     const int frame = event->data.adv.frame;
 
-
     p1sw_0 = PLsw[0][0] = inputs[0];
     p2sw_0 = PLsw[1][0] = inputs[1];
     p1sw_1 = PLsw[0][1] = recall_input(0, frame - 1);
@@ -755,7 +755,9 @@ static void process_session() {
         case GekkoDesyncDetected:
             const int frame = event->data.desynced.frame;
             printf(
-                "⚠️ desync detected at frame %d (0x%X vs 0x%X)\n", frame, event->data.desynced.local_checksum,
+                "⚠️ desync detected at frame %d (0x%X vs 0x%X)\n",
+                frame,
+                event->data.desynced.local_checksum,
                 event->data.desynced.remote_checksum
             );
 
@@ -980,8 +982,12 @@ void Netplay_InjectStressBootInput() {
 
     if (stress_boot_timer % 60 == 0) {
         stress_trace(
-            "driving menus, frame %d: menu cond %d, G_No %d/%d/%d", stress_boot_timer, task[TASK_MENU].condition,
-            G_No[0], G_No[1], G_No[2]
+            "driving menus, frame %d: menu cond %d, G_No %d/%d/%d",
+            stress_boot_timer,
+            task[TASK_MENU].condition,
+            G_No[0],
+            G_No[1],
+            G_No[2]
         );
     }
 

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -33,7 +33,6 @@
 #include <SDL3_net/SDL_net.h>
 
 #include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 #define INPUT_HISTORY_MAX 120
@@ -227,19 +226,19 @@ static void stress_trace(const char* fmt, ...) {
     char path[512];
     stress_path(path, sizeof(path), "stress-trace.log");
 
-    FILE* file = fopen(path, "a");
+    SDL_IOStream* io = SDL_IOFromFile(path, "a");
 
-    if (file == NULL) {
+    if (io == NULL) {
         return;
     }
 
     va_list args;
     va_start(args, fmt);
-    vfprintf(file, fmt, args);
+    SDL_IOvprintf(io, fmt, args);
     va_end(args);
 
-    fputc('\n', file);
-    fclose(file);
+    SDL_IOprintf(io, "\n");
+    SDL_CloseIO(io);
 }
 
 static u32 stress_random() {
@@ -291,7 +290,7 @@ static void configure_stress_session(GekkoConfig* config) {
     config->check_distance = stress_check_distance;
 
     if (!gekko_create(&session, GekkoStressSession)) {
-        printf("Session is already running! probably incorrect.\n");
+        SDL_Log("Session is already running! probably incorrect.");
         return;
     }
 
@@ -335,7 +334,7 @@ static void configure_gekko() {
     if (gekko_create(&session, GekkoGameSession)) {
         gekko_start(session, &config);
     } else {
-        printf("Session is already running! probably incorrect.\n");
+        SDL_Log("Session is already running! probably incorrect.");
     }
 
     NET_DatagramSocket* mm_sock = Fistbump_GetSocket();
@@ -357,8 +356,7 @@ static void configure_gekko() {
     gekko_net_adapter_set(session, SDLNetAdapter_Create(active_sock));
 #endif
 
-    printf("starting a session for player %d at port %hu\n", player_number, local_port);
-    fflush(stdout); // has to survive the window being closed
+    SDL_Log("starting a session for player %d at port %hu", player_number, local_port);
 
     char remote_address_str[100];
     SDL_snprintf(remote_address_str, sizeof(remote_address_str), "%s:%hu", remote_ip, remote_port);
@@ -529,7 +527,7 @@ static void dump_state(const State* src, const char* relative) {
     SDL_IOStream* io = SDL_IOFromFile(filename, "w");
 
     if (io == NULL) {
-        printf("Could not write %s: %s\n", filename, SDL_GetError());
+        SDL_Log("Could not write %s: %s", filename, SDL_GetError());
         return;
     }
 
@@ -543,7 +541,7 @@ static void dump_saved_state(int frame) {
     // A desync can be reported after the slot has been reused; dumping it anyway
     // would compare two unrelated frames.
     if (state_buffer_frame[slot] != frame) {
-        printf("Frame %d has already been overwritten in the state buffer, not dumping.\n", frame);
+        SDL_Log("Frame %d has already been overwritten in the state buffer, not dumping.", frame);
         return;
     }
 
@@ -561,7 +559,7 @@ static void dump_desync_pair(int frame) {
     const int slot = frame % STATE_BUFFER_MAX;
 
     if (state_buffer_frame[slot] != frame || resim_state_buffer_frame[slot] != frame) {
-        printf("Frame %d is no longer in the state buffer, can't dump a pair.\n", frame);
+        SDL_Log("Frame %d is no longer in the state buffer, can't dump a pair.", frame);
         return;
     }
 
@@ -734,28 +732,28 @@ static void process_session() {
 
         switch (event->type) {
         case GekkoPlayerSyncing:
-            printf("🔴 player syncing\n");
+            SDL_Log("🔴 player syncing");
             // FIXME: Show status to the player
             break;
 
         case GekkoPlayerConnected:
-            printf("🔴 player connected\n");
+            SDL_Log("🔴 player connected");
             break;
 
         case GekkoPlayerDisconnected:
-            printf("🔴 player disconnected\n");
+            SDL_Log("🔴 player disconnected");
             handle_disconnection();
             break;
 
         case GekkoSessionStarted:
-            printf("🔴 session started\n");
+            SDL_Log("🔴 session started");
             session_state = NETPLAY_SESSION_RUNNING;
             break;
 
         case GekkoDesyncDetected:
             const int frame = event->data.desynced.frame;
-            printf(
-                "⚠️ desync detected at frame %d (0x%X vs 0x%X)\n",
+            SDL_Log(
+                "⚠️ desync detected at frame %d (0x%X vs 0x%X)",
                 frame,
                 event->data.desynced.local_checksum,
                 event->data.desynced.remote_checksum
@@ -950,7 +948,7 @@ void Netplay_BeginStress(int seed, int check_distance, int frames) {
     // is reported, which is check_distance frames after the fact.
     if (stress_check_distance >= STATE_BUFFER_MAX) {
         stress_check_distance = STATE_BUFFER_MAX - 1;
-        printf("Clamped stress check distance to %d.\n", stress_check_distance);
+        SDL_Log("Clamped stress check distance to %d.", stress_check_distance);
     }
 #endif
 }

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -190,8 +190,11 @@ static void setup_vs_mode() {
     G_Timer = 0;
 
     // bg_initialize() reinitialises only part of each layer, and l_limit/r_limit are
-    // written by the opening alone.
+    // written by the opening alone. scno is one of those: the attract sequence leaves
+    // it at 3 and the stage only assigns it on frame 2.
     SDL_zeroa(bg_w.bgw);
+    bg_w.scno = 0;
+    bg_w.scrno = 0;
 
     Deley_Shot_No[0] = 0;
     Deley_Shot_No[1] = 0;

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -180,7 +180,18 @@ static void setup_vs_mode() {
     Mode_Type = MODE_NETWORK;
     cpExitTask(TASK_MENU);
 
-    E_Timer = 0; // E_Timer can have different values depending on when the session was initiated
+    // These depend on when the session was initiated
+    E_Timer = 0;
+    SDL_zeroa(E_No);
+
+    // Peers spend different amounts of time in the menus, and nothing on the way
+    // into a fight clears what that leaves behind.
+    Next_Demo = 0;
+    G_Timer = 0;
+
+    // bg_initialize() reinitialises only part of each layer, and l_limit/r_limit are
+    // written by the opening alone.
+    SDL_zeroa(bg_w.bgw);
 
     Deley_Shot_No[0] = 0;
     Deley_Shot_No[1] = 0;

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -552,7 +552,9 @@ static void dump_desync_pair(int frame) {
 }
 #endif
 
-#define SDL_copya(dst, src) SDL_memcpy(dst, src, sizeof(src))
+#define SDL_copya(dst, src)                                                                                            \
+    _Static_assert(sizeof(dst) == sizeof(src), #dst " and " #src " differ in size");                                   \
+    SDL_memcpy(dst, src, sizeof(src))
 
 static void gather_state(State* dst) {
     // GameState

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -7,7 +7,9 @@
 #include "platform/netplay/game_state.h"
 #include "platform/netplay/sdl_net_adapter.h"
 #include "port/paths.h"
+#include "sf33rd/AcrSDK/common/pad.h"
 #include "sf33rd/Source/Game/effect/effect.h"
+#include "sf33rd/Source/Game/engine/cmd_data.h"
 #include "sf33rd/Source/Game/engine/grade.h"
 #include "sf33rd/Source/Game/engine/plcnt.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
@@ -30,10 +32,14 @@
 #include <SDL3/SDL.h>
 #include <SDL3_net/SDL_net.h>
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #define INPUT_HISTORY_MAX 120
+#define STRESS_CHECK_DISTANCE_DEFAULT 8
+#define GAME_STATE_FIGHT 2 // G_No[1] while a round is being played
+#define STRESS_PAD_CONNECTED 2 // Interface_Type value keyConvert() uses for a present pad
 #define FRAME_SKIP_TIMER_MAX 60 // Allow skipping a frame roughly every second
 #define STATS_UPDATE_TIMER_MAX 60
 #define DELAY_FRAMES 1
@@ -70,6 +76,16 @@ static int matchmaking_server_port = 9000;
 static bool matchmaking_pending = false;
 static bool direct_p2p_configured = false;
 static bool direct_p2p_pending = false;
+static bool stress_pending = false;
+static bool stress_mode = false;
+static u32 stress_rng = 0;
+static int stress_check_distance = 0;
+static int stress_frame_limit = 0;
+static int stress_frames_run = 0;
+static int stress_desyncs = 0;
+static int stress_boot_timer = 0;
+static bool stress_waiting_for_match = false;
+static const char* stress_out_dir = ".";
 static NET_DatagramSocket* p2p_sock = NULL;
 static u16 input_history[2][INPUT_HISTORY_MAX] = { 0 };
 static float frames_behind = 0;
@@ -82,8 +98,35 @@ static NetworkStats network_stats = { 0 };
 
 #if DEBUG
 #define STATE_BUFFER_MAX 20
+#define STATE_SLOT_EMPTY (-1)
 
 static State state_buffer[STATE_BUFFER_MAX] = { 0 };
+static int state_buffer_frame[STATE_BUFFER_MAX] = { 0 };
+
+// A frame is saved when first simulated and again after a rollback re-simulates it.
+static State resim_state_buffer[STATE_BUFFER_MAX] = { 0 };
+static int resim_state_buffer_frame[STATE_BUFFER_MAX] = { 0 };
+static u32 state_buffer_checksum[STATE_BUFFER_MAX] = { 0 };
+
+// Only the first re-simulation that disagrees is worth keeping.
+static bool stress_pair_dumped = false;
+
+static void reset_state_buffers() {
+    for (int i = 0; i < STATE_BUFFER_MAX; i++) {
+        state_buffer_frame[i] = STATE_SLOT_EMPTY;
+        resim_state_buffer_frame[i] = STATE_SLOT_EMPTY;
+    }
+
+    stress_pair_dumped = false;
+}
+
+static int state_slot(int frame) {
+    if (frame < 0) {
+        frame += STATE_BUFFER_MAX;
+    }
+
+    return frame % STATE_BUFFER_MAX;
+}
 #endif
 
 #if defined(LOSSY_ADAPTER)
@@ -159,6 +202,100 @@ static void configure_lossy_adapter(NET_DatagramSocket* sock) {
 }
 #endif
 
+/// Builds a path inside the run's output directory, so parallel runs stay separate.
+static void stress_path(char* dst, size_t size, const char* relative) {
+    SDL_snprintf(dst, size, "%s/%s", stress_out_dir, relative);
+}
+
+/// Appends to stress-trace.log. A stress run is unattended, so the trace has to
+/// survive however the game was launched.
+static void stress_trace(const char* fmt, ...) {
+    char path[512];
+    stress_path(path, sizeof(path), "stress-trace.log");
+
+    FILE* file = fopen(path, "a");
+
+    if (file == NULL) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(file, fmt, args);
+    va_end(args);
+
+    fputc('\n', file);
+    fclose(file);
+}
+
+static u32 stress_random() {
+    // xorshift32, so a seed reproduces the exact same run.
+    stress_rng ^= stress_rng << 13;
+    stress_rng ^= stress_rng >> 17;
+    stress_rng ^= stress_rng << 5;
+    return stress_rng;
+}
+
+/// Holds presses for a few frames at a time, which exercises moves and cancels
+/// rather than one-frame noise.
+static u16 stress_random_input(int player) {
+    static const u16 directions[] = { 0,
+                                      SWK_UP,
+                                      SWK_DOWN,
+                                      SWK_LEFT,
+                                      SWK_RIGHT,
+                                      SWK_UP | SWK_LEFT,
+                                      SWK_UP | SWK_RIGHT,
+                                      SWK_DOWN | SWK_LEFT,
+                                      SWK_DOWN | SWK_RIGHT };
+
+    static const u16 attacks[] = { SWK_WEST,  SWK_NORTH,          SWK_RIGHT_SHOULDER, SWK_LEFT_SHOULDER,
+                                   SWK_SOUTH, SWK_RIGHT_TRIGGER };
+
+    static u16 held[2] = { 0, 0 };
+    static int hold_frames[2] = { 0, 0 };
+
+    if (hold_frames[player] > 0) {
+        hold_frames[player] -= 1;
+        return held[player];
+    }
+
+    u16 input = directions[stress_random() % SDL_arraysize(directions)];
+
+    // Roughly a third of the time, press an attack alongside the direction.
+    if (stress_random() % 3 == 0) {
+        input |= attacks[stress_random() % SDL_arraysize(attacks)];
+    }
+
+    held[player] = input;
+    hold_frames[player] = (int)(stress_random() % 6);
+
+    return input;
+}
+
+static void configure_stress_session(GekkoConfig* config) {
+    config->check_distance = stress_check_distance;
+
+    if (!gekko_create(&session, GekkoStressSession)) {
+        printf("Session is already running! probably incorrect.\n");
+        return;
+    }
+
+    gekko_start(session, config);
+
+    // A stress session simulates both sides locally, so both actors are local.
+    for (int i = 0; i < PLAYER_COUNT; i++) {
+        gekko_add_actor(session, GekkoLocalPlayer, NULL);
+    }
+
+    player_handle = 0;
+
+    stress_trace(
+        "session created (seed %u, check distance %d, frame limit %d)", stress_rng, stress_check_distance,
+        stress_frame_limit
+    );
+}
+
 static void configure_gekko() {
     GekkoConfig config;
     SDL_zero(config);
@@ -171,7 +308,13 @@ static void configure_gekko() {
 
 #if DEBUG
     config.desync_detection = true;
+    reset_state_buffers();
 #endif
+
+    if (stress_mode) {
+        configure_stress_session(&config);
+        return;
+    }
 
     if (gekko_create(&session, GekkoGameSession)) {
         gekko_start(session, &config);
@@ -340,29 +483,72 @@ static void clean_state_pointers(State* state) {
 /// Save state in state buffer.
 /// @return Pointer to state as it has been saved.
 static const State* note_state(const State* state, int frame) {
-    if (frame < 0) {
-        frame += STATE_BUFFER_MAX;
+    const int slot = state_slot(frame);
+    State* dst;
+
+    if (state_buffer_frame[slot] == frame) {
+        // Already stored once, so this save comes from a rollback re-simulation.
+        dst = &resim_state_buffer[slot];
+        resim_state_buffer_frame[slot] = frame;
+    } else {
+        dst = &state_buffer[slot];
+        state_buffer_frame[slot] = frame;
+        resim_state_buffer_frame[slot] = STATE_SLOT_EMPTY;
     }
 
-    State* dst = &state_buffer[frame % STATE_BUFFER_MAX];
     SDL_memcpy(dst, state, sizeof(State));
     clean_state_pointers(dst);
     return dst;
 }
 
-static void dump_state(const State* src, const char* filename) {
+static void dump_state(const State* src, const char* relative) {
+    char states_dir[512];
+    stress_path(states_dir, sizeof(states_dir), "states");
+    SDL_CreateDirectory(states_dir);
+
+    char filename[512];
+    stress_path(filename, sizeof(filename), relative);
+
     SDL_IOStream* io = SDL_IOFromFile(filename, "w");
+
+    if (io == NULL) {
+        printf("Could not write %s: %s\n", filename, SDL_GetError());
+        return;
+    }
+
     SDL_WriteIO(io, src, sizeof(State));
     SDL_CloseIO(io);
 }
 
 static void dump_saved_state(int frame) {
-    const State* src = &state_buffer[frame % STATE_BUFFER_MAX];
+    const int slot = frame % STATE_BUFFER_MAX;
+
+    // The re-simulated state is the one the session ended up agreeing on.
+    const State* src =
+        resim_state_buffer_frame[slot] == frame ? &resim_state_buffer[slot] : &state_buffer[slot];
 
     char filename[100];
     SDL_snprintf(filename, sizeof(filename), "states/%d_%d", player_handle, frame);
 
     dump_state(src, filename);
+}
+
+/// Dump both simulations of a frame so compare_states.py can diff them as a pair.
+static void dump_desync_pair(int frame) {
+    const int slot = frame % STATE_BUFFER_MAX;
+
+    if (state_buffer_frame[slot] != frame || resim_state_buffer_frame[slot] != frame) {
+        printf("Frame %d is no longer in the state buffer, can't dump a pair.\n", frame);
+        return;
+    }
+
+    char filename[100];
+
+    SDL_snprintf(filename, sizeof(filename), "states/0_%d", frame);
+    dump_state(&state_buffer[slot], filename);
+
+    SDL_snprintf(filename, sizeof(filename), "states/1_%d", frame);
+    dump_state(&resim_state_buffer[slot], filename);
 }
 #endif
 
@@ -392,8 +578,24 @@ static void save_state(GekkoGameEvent* event) {
 
 #if DEBUG
     const int frame = event->data.save.frame;
+    const int slot = state_slot(frame);
+    const bool is_resimulation = state_buffer_frame[slot] == frame;
+
     const State* saved_state = note_state(dst, frame);
-    *event->data.save.checksum = calculate_checksum(saved_state);
+    const u32 checksum = calculate_checksum(saved_state);
+
+    *event->data.save.checksum = checksum;
+
+    if (!is_resimulation) {
+        state_buffer_checksum[slot] = checksum;
+    } else if (stress_mode && !stress_pair_dumped && checksum != state_buffer_checksum[slot]) {
+        // Catch the divergence here rather than when the session reports it:
+        // by then this frame has been re-simulated several more times and the
+        // buffer may hold a pass that happens to agree.
+        stress_pair_dumped = true;
+        dump_desync_pair(frame);
+        stress_trace("re-simulation of frame %d diverged (0x%X vs 0x%X)", frame, state_buffer_checksum[slot], checksum);
+    }
 #endif
 }
 
@@ -416,6 +618,30 @@ static void load_state(const State* src) {
 static void load_state_from_event(GekkoGameEvent* event) {
     const State* src = (State*)event->data.load.state;
     load_state(src);
+
+#if DEBUG
+    // Round-trip check: re-gathering right after a load must reproduce the state
+    // that was loaded. Anything that differs is state the save/load pair drops.
+    static bool round_trip_checked = false;
+
+    if (stress_mode && !round_trip_checked) {
+        round_trip_checked = true;
+
+        static State before;
+        static State after;
+
+        SDL_memcpy(&before, src, sizeof(State));
+        gather_state(&after);
+
+        clean_state_pointers(&before);
+        clean_state_pointers(&after);
+
+        dump_state(&before, "states/0_9999");
+        dump_state(&after, "states/1_9999");
+
+        stress_trace("round-trip dump written for frame %d", event->data.load.frame);
+    }
+#endif
 }
 
 static bool game_ready_to_run_character_select() {
@@ -438,6 +664,7 @@ static void step_game(bool render) {
 static void advance_game(GekkoGameEvent* event, bool render) {
     const u16* inputs = (u16*)event->data.adv.inputs;
     const int frame = event->data.adv.frame;
+
 
     p1sw_0 = PLsw[0][0] = inputs[0];
     p2sw_0 = PLsw[1][0] = inputs[1];
@@ -465,8 +692,15 @@ static void process_session() {
 
     gekko_network_poll(session);
 
-    u16 local_inputs = get_inputs();
-    gekko_add_local_input(session, player_handle, &local_inputs);
+    if (stress_mode) {
+        for (int i = 0; i < PLAYER_COUNT; i++) {
+            u16 stress_inputs = stress_random_input(i);
+            gekko_add_local_input(session, i, &stress_inputs);
+        }
+    } else {
+        u16 local_inputs = get_inputs();
+        gekko_add_local_input(session, player_handle, &local_inputs);
+    }
 
     int session_event_count = 0;
     GekkoSessionEvent** session_events = gekko_session_events(session, &session_event_count);
@@ -496,10 +730,29 @@ static void process_session() {
 
         case GekkoDesyncDetected:
             const int frame = event->data.desynced.frame;
-            printf("⚠️ desync detected at frame %d\n", frame);
+            printf(
+                "⚠️ desync detected at frame %d (0x%X vs 0x%X)\n", frame, event->data.desynced.local_checksum,
+                event->data.desynced.remote_checksum
+            );
 
 #if DEBUG
-            dump_saved_state(frame);
+            if (stress_mode) {
+                stress_desyncs += 1;
+                stress_trace("desync at frame %d after %d frames", frame, stress_frames_run);
+
+                if (!stress_pair_dumped) {
+                    // The divergence was outside the window save_state watches.
+                    stress_pair_dumped = true;
+                    dump_desync_pair(frame);
+                }
+
+                // Finding one is the whole point of the run, so stop here and
+                // leave the dumps for compare_states.py.
+                stress_trace("exiting: desync found after %d frames", stress_frames_run);
+                SDLApp_Exit();
+            } else {
+                dump_saved_state(frame);
+            }
 #endif
             break;
 
@@ -530,6 +783,14 @@ static void process_events(bool drawing_allowed) {
             const bool rolling_back = event->data.adv.rolling_back;
             advance_game(event, drawing_allowed && !rolling_back);
             frames_rolled_back += rolling_back ? 1 : 0;
+
+            if (stress_mode && !rolling_back) {
+                stress_frames_run += 1;
+
+                if (stress_frames_run % 60 == 0) {
+                    stress_trace("stress frame %d (%d desync(s))", stress_frames_run, stress_desyncs);
+                }
+            }
             break;
 
         case GekkoSaveEvent:
@@ -644,6 +905,143 @@ void Netplay_TickDirectP2P() {
     session_state = NETPLAY_SESSION_TRANSITIONING;
 }
 
+void Netplay_SetStressOutputDir(const char* directory) {
+    if (directory != NULL) {
+        stress_out_dir = directory;
+    }
+}
+
+void Netplay_BeginStress(int seed, int check_distance, int frames) {
+    // A zero seed would make xorshift produce nothing but zeroes.
+    stress_rng = seed != 0 ? (u32)seed : 1;
+
+    stress_check_distance = check_distance > 0 ? check_distance : STRESS_CHECK_DISTANCE_DEFAULT;
+    stress_frame_limit = frames;
+    stress_pending = true;
+
+#if DEBUG
+    // Both simulations of a frame have to still be in the buffer when the desync
+    // is reported, which is check_distance frames after the fact.
+    if (stress_check_distance >= STATE_BUFFER_MAX) {
+        stress_check_distance = STATE_BUFFER_MAX - 1;
+        printf("Clamped stress check distance to %d.\n", stress_check_distance);
+    }
+#endif
+}
+
+static bool game_is_in_a_fight() {
+    return G_No[1] == GAME_STATE_FIGHT;
+}
+
+/// A stress run is unattended, so it drives the boot screens and character
+/// select itself. Called after keyConvert() has filled the pad buffers, and only
+/// until the session takes over the inputs.
+void Netplay_InjectStressBootInput() {
+    if (!stress_pending && !stress_waiting_for_match && !stress_mode) {
+        return;
+    }
+
+    // Both players are simulated, but only port 1 has real hardware behind it.
+    // keyConvert() clears the other port every frame, which makes the game ask
+    // for a controller to be reconnected mid-match.
+    Interface_Type[0] = STRESS_PAD_CONNECTED;
+    Interface_Type[1] = STRESS_PAD_CONNECTED;
+
+    if (stress_mode) {
+        // The session drives the inputs once it is running.
+        return;
+    }
+
+    stress_boot_timer += 1;
+
+    if (stress_boot_timer % 60 == 0) {
+        stress_trace(
+            "driving menus, frame %d: menu cond %d, G_No %d/%d/%d", stress_boot_timer, task[TASK_MENU].condition,
+            G_No[0], G_No[1], G_No[2]
+        );
+    }
+
+    if (stress_pending) {
+        // Tap rather than hold: the screens react to a press, not to the button
+        // being down, and holding it would only ever produce one edge.
+        if ((stress_boot_timer / 4) % 2 == 0) {
+            p1sw_buff |= SWK_START;
+        }
+
+        return;
+    }
+
+    // Character select and the screens around it. Both sides need to pick, so
+    // feed both pads and tap start to get through the VS screens.
+    p1sw_buff |= stress_random_input(0);
+    p2sw_buff |= stress_random_input(1);
+
+    if ((stress_boot_timer / 8) % 2 == 0) {
+        p1sw_buff |= SWK_START;
+        p2sw_buff |= SWK_START;
+    }
+}
+
+void Netplay_TickStress() {
+    if (stress_pending) {
+        // Wait for the game to reach the menus before taking it into VS mode.
+        if (task[TASK_MENU].condition != 1) {
+            return;
+        }
+
+        stress_trace("entering versus mode from G_No %d/%d/%d", G_No[0], G_No[1], G_No[2]);
+
+        stress_pending = false;
+        stress_waiting_for_match = true;
+        setup_vs_mode();
+
+        // Character select is driven by the pads, not by the session, so run it
+        // as a local versus match.
+        Mode_Type = MODE_VERSUS;
+        return;
+    }
+
+    if (!stress_waiting_for_match || !game_is_in_a_fight()) {
+        return;
+    }
+
+    // The fight is running, so hand the simulation over to the stress session.
+    // Starting here keeps the rollback away from character select and stage
+    // loading, which are far too expensive to re-simulate every frame.
+    stress_trace("fight reached, creating session at G_No %d/%d/%d", G_No[0], G_No[1], G_No[2]);
+
+    stress_waiting_for_match = false;
+    stress_mode = true;
+
+    const int previous_operators[PLAYER_COUNT] = { plw[0].wu.operator, plw[1].wu.operator };
+
+    // Both sides have to read their lever from the session. A CPU-controlled
+    // player derives it from cpu_algorithm() instead, whose state isn't part of
+    // the saved State, so it would diverge on every rollback.
+    for (int i = 0; i < PLAYER_COUNT; i++) {
+        Operator_Status[i] = 1;
+        plw[i].wu.operator = 1;
+    }
+
+    stress_trace("operators were %d/%d, forced to human", previous_operators[0], previous_operators[1]);
+
+    SDL_zeroa(input_history);
+    frames_behind = 0;
+    frame_skip_timer = 0;
+
+    configure_gekko();
+    session_state = NETPLAY_SESSION_RUNNING;
+}
+
+static void check_stress_frame_limit() {
+    if (!stress_mode || stress_frame_limit <= 0 || stress_frames_run < stress_frame_limit) {
+        return;
+    }
+
+    stress_trace("exiting: frame limit reached after %d frames, %d desync(s)", stress_frames_run, stress_desyncs);
+    SDLApp_Exit();
+}
+
 void Netplay_SetMatchmakingParams(const char* server_ip, int server_port) {
     matchmaking_server_ip = server_ip;
     matchmaking_server_port = server_port;
@@ -712,6 +1110,16 @@ void Netplay_CancelMatchmaking() {
 void Netplay_Run() {
     switch (session_state) {
     case NETPLAY_SESSION_TRANSITIONING:
+        if (stress_mode) {
+            static int transition_trace = 0;
+
+            if (transition_trace++ % 60 == 0) {
+                stress_trace(
+                    "transitioning: G_No %d/%d/%d, ready %d", G_No[0], G_No[1], G_No[2], transition_ready_frames
+                );
+            }
+        }
+
         if (game_ready_to_run_character_select()) {
             transition_ready_frames += 1;
         } else {
@@ -722,7 +1130,9 @@ void Netplay_Run() {
 
         if (transition_ready_frames >= 2) {
             configure_gekko();
-            session_state = NETPLAY_SESSION_CONNECTING;
+            // A stress session is local, so there is no handshake to wait for
+            // and no GekkoSessionStarted event will ever arrive.
+            session_state = stress_mode ? NETPLAY_SESSION_RUNNING : NETPLAY_SESSION_CONNECTING;
         }
 
         break;
@@ -730,6 +1140,7 @@ void Netplay_Run() {
     case NETPLAY_SESSION_CONNECTING:
     case NETPLAY_SESSION_RUNNING:
         run_netplay();
+        check_stress_frame_limit();
         break;
 
     case NETPLAY_SESSION_EXITING:

--- a/src/platform/netplay/netplay.c
+++ b/src/platform/netplay/netplay.c
@@ -353,6 +353,7 @@ static void configure_gekko() {
 #endif
 
     printf("starting a session for player %d at port %hu\n", player_number, local_port);
+    fflush(stdout); // has to survive the window being closed
 
     char remote_address_str[100];
     SDL_snprintf(remote_address_str, sizeof(remote_address_str), "%s:%hu", remote_ip, remote_port);
@@ -532,7 +533,14 @@ static void dump_state(const State* src, const char* relative) {
 }
 
 static void dump_saved_state(int frame) {
-    const int slot = frame % STATE_BUFFER_MAX;
+    const int slot = state_slot(frame);
+
+    // A desync can be reported after the slot has been reused; dumping it anyway
+    // would compare two unrelated frames.
+    if (state_buffer_frame[slot] != frame) {
+        printf("Frame %d has already been overwritten in the state buffer, not dumping.\n", frame);
+        return;
+    }
 
     // The re-simulated state is the one the session ended up agreeing on.
     const State* src =

--- a/src/platform/netplay/netplay.h
+++ b/src/platform/netplay/netplay.h
@@ -23,10 +23,6 @@ void Netplay_SetParams(int player, const char* ip);
 bool Netplay_IsDirectP2PConfigured(); // true when a remote was given on the command line
 void Netplay_BeginDirectP2P();
 void Netplay_TickDirectP2P();
-void Netplay_SetStressOutputDir(const char* directory);
-void Netplay_BeginStress(int seed, int check_distance, int frames);
-void Netplay_TickStress();
-void Netplay_InjectStressBootInput();
 void Netplay_SetMatchmakingParams(const char* server_ip, int server_port);
 void Netplay_BeginMatchmaking();
 void Netplay_TickMatchmaking();

--- a/src/platform/netplay/netplay.h
+++ b/src/platform/netplay/netplay.h
@@ -23,6 +23,10 @@ void Netplay_SetParams(int player, const char* ip);
 bool Netplay_IsDirectP2PConfigured(); // true when a remote was given on the command line
 void Netplay_BeginDirectP2P();
 void Netplay_TickDirectP2P();
+void Netplay_SetStressOutputDir(const char* directory);
+void Netplay_BeginStress(int seed, int check_distance, int frames);
+void Netplay_TickStress();
+void Netplay_InjectStressBootInput();
 void Netplay_SetMatchmakingParams(const char* server_ip, int server_port);
 void Netplay_BeginMatchmaking();
 void Netplay_TickMatchmaking();

--- a/src/platform/netplay/netplay_base.h
+++ b/src/platform/netplay/netplay_base.h
@@ -1,0 +1,40 @@
+#ifndef NETPLAY_BASE_H
+#define NETPLAY_BASE_H
+
+#if NETPLAY_ENABLED
+
+#include "platform/netplay/game_state.h"
+#include "sf33rd/Source/Game/effect/effect.h"
+#include "types.h"
+
+#define PLAYER_COUNT 2
+
+typedef struct EffectState {
+    s16 frwctr;
+    s16 frwctr_min;
+    s16 head_ix[8];
+    s16 tail_ix[8];
+    s16 exec_tm[8];
+    uintptr_t frw[EFFECT_MAX][448];
+    s16 frwque[EFFECT_MAX];
+} EffectState;
+
+typedef struct State {
+    GameState gs;
+    EffectState es;
+} State;
+
+#if DEBUG
+#define STATE_BUFFER_MAX 20
+#endif
+
+void NetplayBase_SetupVsMode();
+void NetplayBase_StartStressSession();
+
+#if DEBUG
+void NetplayBase_DumpDesyncPair(int frame);
+#endif
+
+#endif // NETPLAY_ENABLED
+
+#endif

--- a/src/platform/netplay/netplay_stress.c
+++ b/src/platform/netplay/netplay_stress.c
@@ -1,0 +1,304 @@
+#if NETPLAY_ENABLED
+
+#include "platform/netplay/netplay_stress.h"
+#include "core/app.h"
+#include "main.h"
+#include "platform/netplay/netplay_base.h"
+#include "sf33rd/AcrSDK/common/pad.h"
+#include "sf33rd/Source/Game/engine/workuser.h"
+#include "sf33rd/Source/Game/menu/menu.h"
+#include "sf33rd/Source/Game/system/work_sys.h"
+#include "types.h"
+
+#include <SDL3/SDL.h>
+
+#include <stdarg.h>
+#include <stdbool.h>
+
+#define STRESS_CHECK_DISTANCE_DEFAULT 8
+#define GAME_STATE_FIGHT 2     // G_No[1] while a round is being played
+#define STRESS_PAD_CONNECTED 2 // Interface_Type value keyConvert() uses for a present pad
+
+static bool stress_pending = false;
+static bool stress_running = false;
+static bool stress_finished = false;
+static bool stress_waiting_for_match = false;
+static u32 stress_rng = 0;
+static int stress_check_distance = 0;
+static int stress_frame_limit = 0;
+static int stress_frames_run = 0;
+static int stress_desyncs = 0;
+static int stress_boot_timer = 0;
+static const char* stress_out_dir = ".";
+
+// Only the first re-simulation that disagrees is worth keeping.
+static bool stress_pair_dumped = false;
+
+void Stress_Path(char* dst, size_t size, const char* relative) {
+    SDL_snprintf(dst, size, "%s/%s", stress_out_dir, relative);
+}
+
+/// A stress run is unattended, so its trace goes to a file rather than stdout.
+void Stress_Trace(const char* fmt, ...) {
+    char path[512];
+    Stress_Path(path, sizeof(path), "stress-trace.log");
+
+    SDL_IOStream* io = SDL_IOFromFile(path, "a");
+
+    if (io == NULL) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    SDL_IOvprintf(io, fmt, args);
+    va_end(args);
+
+    SDL_IOprintf(io, "\n");
+    SDL_CloseIO(io);
+}
+
+static u32 stress_random() {
+    // xorshift32, so a seed reproduces the exact same run.
+    stress_rng ^= stress_rng << 13;
+    stress_rng ^= stress_rng >> 17;
+    stress_rng ^= stress_rng << 5;
+    return stress_rng;
+}
+
+/// Holds presses for a few frames at a time, which exercises moves and cancels
+/// rather than one-frame noise.
+u16 Stress_NextInput(int player) {
+    static const u16 directions[] = { 0,
+                                      SWK_UP,
+                                      SWK_DOWN,
+                                      SWK_LEFT,
+                                      SWK_RIGHT,
+                                      SWK_UP | SWK_LEFT,
+                                      SWK_UP | SWK_RIGHT,
+                                      SWK_DOWN | SWK_LEFT,
+                                      SWK_DOWN | SWK_RIGHT };
+
+    static const u16 attacks[] = { SWK_WEST,          SWK_NORTH, SWK_RIGHT_SHOULDER,
+                                   SWK_LEFT_SHOULDER, SWK_SOUTH, SWK_RIGHT_TRIGGER };
+
+    static u16 held[PLAYER_COUNT] = { 0, 0 };
+    static int hold_frames[PLAYER_COUNT] = { 0, 0 };
+
+    if (hold_frames[player] > 0) {
+        hold_frames[player] -= 1;
+        return held[player];
+    }
+
+    u16 input = directions[stress_random() % SDL_arraysize(directions)];
+
+    if (stress_random() % 3 == 0) {
+        input |= attacks[stress_random() % SDL_arraysize(attacks)];
+    }
+
+    held[player] = input;
+    hold_frames[player] = (int)(stress_random() % 6);
+
+    return input;
+}
+
+void Stress_SetOutputDir(const char* directory) {
+    if (directory != NULL) {
+        stress_out_dir = directory;
+    }
+}
+
+void Stress_Begin(int seed, int check_distance, int frames) {
+    // A zero seed would make xorshift produce nothing but zeroes.
+    stress_rng = seed != 0 ? (u32)seed : 1;
+
+    stress_check_distance = check_distance > 0 ? check_distance : STRESS_CHECK_DISTANCE_DEFAULT;
+    stress_frame_limit = frames;
+    stress_pending = true;
+
+#if DEBUG
+    // Both simulations of a frame have to still be in the buffer when the desync
+    // is reported, which is check_distance frames after the fact.
+    if (stress_check_distance >= STATE_BUFFER_MAX) {
+        stress_check_distance = STATE_BUFFER_MAX - 1;
+        SDL_Log("Clamped stress check distance to %d.", stress_check_distance);
+    }
+#endif
+}
+
+bool Stress_IsRequested() {
+    return stress_pending || stress_waiting_for_match || stress_running;
+}
+
+bool Stress_IsRunning() {
+    return stress_running;
+}
+
+bool Stress_IsFinished() {
+    return stress_finished;
+}
+
+void Stress_CreateSession(GekkoConfig* config, GekkoSession** session, int* player_handle) {
+    config->check_distance = stress_check_distance;
+
+    if (!gekko_create(session, GekkoStressSession)) {
+        SDL_Log("Session is already running! probably incorrect.");
+        return;
+    }
+
+    gekko_start(*session, config);
+
+    for (int i = 0; i < PLAYER_COUNT; i++) {
+        gekko_add_actor(*session, GekkoLocalPlayer, NULL);
+    }
+
+    *player_handle = 0;
+
+    Stress_Trace(
+        "session created (seed %u, check distance %d, frame limit %d)",
+        stress_rng,
+        stress_check_distance,
+        stress_frame_limit
+    );
+}
+
+static bool game_is_in_a_fight() {
+    return G_No[1] == GAME_STATE_FIGHT;
+}
+
+void Stress_InjectBootInput() {
+    if (!Stress_IsRequested()) {
+        return;
+    }
+
+    // Both players are simulated, but only port 1 has real hardware behind it.
+    // keyConvert() clears the other port every frame, which makes the game ask
+    // for a controller to be reconnected mid-match.
+    Interface_Type[0] = STRESS_PAD_CONNECTED;
+    Interface_Type[1] = STRESS_PAD_CONNECTED;
+
+    if (stress_running) {
+        // The session drives the inputs from here on.
+        return;
+    }
+
+    stress_boot_timer += 1;
+
+    if (stress_boot_timer % 60 == 0) {
+        Stress_Trace(
+            "driving menus, frame %d: menu cond %d, G_No %d/%d/%d",
+            stress_boot_timer,
+            task[TASK_MENU].condition,
+            G_No[0],
+            G_No[1],
+            G_No[2]
+        );
+    }
+
+    if (stress_pending) {
+        // Tap rather than hold: the screens react to a press, not to the button
+        // being down, and holding it would only ever produce one edge.
+        if ((stress_boot_timer / 4) % 2 == 0) {
+            p1sw_buff |= SWK_START;
+        }
+
+        return;
+    }
+
+    p1sw_buff |= Stress_NextInput(0);
+    p2sw_buff |= Stress_NextInput(1);
+
+    if ((stress_boot_timer / 8) % 2 == 0) {
+        p1sw_buff |= SWK_START;
+        p2sw_buff |= SWK_START;
+    }
+}
+
+void Stress_Tick() {
+    if (stress_pending) {
+        if (task[TASK_MENU].condition != 1) {
+            return;
+        }
+
+        Stress_Trace("entering versus mode from G_No %d/%d/%d", G_No[0], G_No[1], G_No[2]);
+
+        stress_pending = false;
+        stress_waiting_for_match = true;
+        NetplayBase_SetupVsMode();
+
+        // Character select is driven by the pads, not by the session, so run it
+        // as a local versus match.
+        Mode_Type = MODE_VERSUS;
+        return;
+    }
+
+    if (!stress_waiting_for_match || !game_is_in_a_fight()) {
+        return;
+    }
+
+    // Starting at the fight keeps the rollback away from character select and
+    // stage loading, which are far too expensive to re-simulate every frame.
+    Stress_Trace("fight reached, creating session at G_No %d/%d/%d", G_No[0], G_No[1], G_No[2]);
+
+    stress_waiting_for_match = false;
+    stress_running = true;
+
+    // Both sides have to read their lever from the session. A CPU-controlled
+    // player derives it from cpu_algorithm() instead, whose state isn't part of
+    // the saved State, so it would diverge on every rollback.
+    for (int i = 0; i < PLAYER_COUNT; i++) {
+        Operator_Status[i] = 1;
+        plw[i].wu.operator = 1;
+    }
+
+    NetplayBase_StartStressSession();
+}
+
+void Stress_OnFrameAdvanced() {
+    stress_frames_run += 1;
+
+    if (stress_frames_run % 60 == 0) {
+        Stress_Trace("stress frame %d (%d desync(s))", stress_frames_run, stress_desyncs);
+    }
+
+    if (stress_frame_limit > 0 && stress_frames_run >= stress_frame_limit) {
+        Stress_Trace("exiting: frame limit reached after %d frames, %d desync(s)", stress_frames_run, stress_desyncs);
+        stress_finished = true;
+        App_Exit();
+    }
+}
+
+void Stress_OnDesync(int frame) {
+    stress_desyncs += 1;
+    Stress_Trace("desync at frame %d after %d frames", frame, stress_frames_run);
+
+#if DEBUG
+    if (!stress_pair_dumped) {
+        // The divergence was outside the window the save hook watches.
+        stress_pair_dumped = true;
+        NetplayBase_DumpDesyncPair(frame);
+    }
+#endif
+
+    // The dumps are left for compare_states.py.
+    Stress_Trace("exiting: desync found after %d frames", stress_frames_run);
+    stress_finished = true;
+    App_Exit();
+}
+
+void Stress_OnResimulationDiverged(int frame, u32 first_checksum, u32 resim_checksum) {
+#if DEBUG
+    if (stress_pair_dumped) {
+        return;
+    }
+
+    // Catch the divergence here rather than when the session reports it: by then
+    // this frame has been re-simulated several more times and the buffer may
+    // hold a pass that happens to agree.
+    stress_pair_dumped = true;
+    NetplayBase_DumpDesyncPair(frame);
+    Stress_Trace("re-simulation of frame %d diverged (0x%X vs 0x%X)", frame, first_checksum, resim_checksum);
+#endif
+}
+
+#endif // NETPLAY_ENABLED

--- a/src/platform/netplay/netplay_stress.c
+++ b/src/platform/netplay/netplay_stress.c
@@ -257,6 +257,16 @@ void Stress_Tick() {
 void Stress_OnFrameAdvanced() {
     stress_frames_run += 1;
 
+    if (!game_is_in_a_fight()) {
+        // The texture cache is not part of the saved State, and the screens after
+        // a match release and reload it. Rolling back across that boundary makes
+        // the game draw a player from an MTS slot that has since been freed.
+        Stress_Trace("exiting: match ended after %d frames, %d desync(s)", stress_frames_run, stress_desyncs);
+        stress_finished = true;
+        App_Exit();
+        return;
+    }
+
     if (stress_frames_run % 60 == 0) {
         Stress_Trace("stress frame %d (%d desync(s))", stress_frames_run, stress_desyncs);
     }

--- a/src/platform/netplay/netplay_stress.h
+++ b/src/platform/netplay/netplay_stress.h
@@ -1,0 +1,37 @@
+#ifndef NETPLAY_STRESS_H
+#define NETPLAY_STRESS_H
+
+#if NETPLAY_ENABLED
+
+#include "types.h"
+
+#include "gekkonet.h"
+
+#include <stdbool.h>
+
+/// A stress session re-simulates the last check_distance frames every update and
+/// compares the resulting checksums against the first pass, so rollback desyncs
+/// surface on one machine without a second peer. The run is unattended: it drives
+/// the boot screens and character select itself, then hands the fight to the session.
+
+void Stress_SetOutputDir(const char* directory);
+void Stress_Begin(int seed, int check_distance, int frames);
+void Stress_Tick();
+void Stress_InjectBootInput();
+
+bool Stress_IsRequested();
+bool Stress_IsRunning();
+bool Stress_IsFinished();
+
+void Stress_Path(char* dst, size_t size, const char* relative);
+void Stress_Trace(const char* fmt, ...);
+
+void Stress_CreateSession(GekkoConfig* config, GekkoSession** session, int* player_handle);
+u16 Stress_NextInput(int player);
+void Stress_OnFrameAdvanced();
+void Stress_OnDesync(int frame);
+void Stress_OnResimulationDiverged(int frame, u32 first_checksum, u32 resim_checksum);
+
+#endif // NETPLAY_ENABLED
+
+#endif

--- a/src/sf33rd/Source/Game/effect/eff79.h
+++ b/src/sf33rd/Source/Game/effect/eff79.h
@@ -4,6 +4,11 @@
 #include "structs.h"
 #include "types.h"
 
+// MARK: - Serialized
+
+extern u8 OK_Appear79[2];
+extern u8 Extra_Counter[2];
+
 void effect_79_move(WORK_Other* ewk);
 s32 effect_79_init(s16 pl_id, s16 plate_id, s16 pos_id, s16 time, s16 Target_BG);
 

--- a/src/sf33rd/Source/Game/rendering/aboutspr.c
+++ b/src/sf33rd/Source/Game/rendering/aboutspr.c
@@ -274,15 +274,16 @@ void Mtrans_use_trans_mode(WORK* wk, s16 bsy) {
         return;
     }
 
+    // Above No_Trans so a frame that skips drawing lands on the same value.
+    if (wk->my_col_mode & 0x400) {
+        wk->my_clear_level = 0x90;
+    }
+
     if (No_Trans) {
         return;
     }
 
     wk->current_colcd &= 0x1FF;
-
-    if (wk->my_col_mode & 0x400) {
-        wk->my_clear_level = 0x90;
-    }
 
     switch (mts[wk->my_mts].mode) {
     case 17:

--- a/tools/compare_states.py
+++ b/tools/compare_states.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from enum import Enum
@@ -115,16 +116,28 @@ class DWARFParser:
         return list(reversed(indices))
 
     def __run_dwarfdump(self, path: Path) -> str:
-        result = subprocess.run(
-            ["dwarfdump", path],
-            capture_output=True,
-            text=True
-        )
+        # LLVM ships the tool as llvm-dwarfdump, which is what MSYS2 provides.
+        candidates = [os.environ["DWARFDUMP"]] if "DWARFDUMP" in os.environ else ["dwarfdump", "llvm-dwarfdump"]
+        errors: list[str] = []
 
-        if result.returncode != 0:
-            raise RuntimeError(f"dwarfdump failed: {result.stderr.strip()}")
+        for candidate in candidates:
+            try:
+                result = subprocess.run(
+                    [candidate, path],
+                    capture_output=True,
+                    text=True
+                )
+            except FileNotFoundError:
+                errors.append(f"{candidate}: not found")
+                continue
 
-        return result.stdout
+            if result.returncode != 0:
+                errors.append(f"{candidate}: {result.stderr.strip()}")
+                continue
+
+            return result.stdout
+
+        raise RuntimeError("dwarfdump failed. " + "; ".join(errors))
 
     def __parse_typedefs(self, lines: list[str]):
         current_type: int | None = None

--- a/tools/stress_desync.py
+++ b/tools/stress_desync.py
@@ -17,14 +17,19 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-NETPLAY_OBJ = Path("CMakeFiles/3sx.dir/src/platform/netplay/netplay.c")
+TOOLS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TOOLS_DIR.parent
+
+# The translation unit that defines State, which is what the dumps are read as.
+NETPLAY_SOURCE = "netplay.c"
 
 # CMake suffixes objects with .obj on Windows and .o everywhere else.
 OBJ_SUFFIXES = [".obj", ".o"]
 
-# build/stress is the optimised harness build; a Debug build works but is about
-# eight times slower, since every re-simulated frame copies and hashes the state.
+# Where docs/building.md installs to. A build outside the repo is found by
+# walking up from THREESX_EXE instead. build/stress is the optimised harness
+# build; a Debug build works but is about eight times slower, since every
+# re-simulated frame copies and hashes the state.
 BUILD_DIRS = [REPO_ROOT / "build" / "stress", REPO_ROOT / "build"]
 
 
@@ -98,14 +103,19 @@ def prepare_run_dir(bin_dir: Path, seed: int) -> Path:
 
 def find_obj(exe: Path) -> Path | None:
     """The object file sits in the build tree the executable was installed from,
-    so walk up from it before falling back to the usual build directories."""
+    so walk up from it before falling back to the usual build directories. Its
+    path within CMakeFiles follows the source tree, so search rather than build
+    it: netplay.c has moved once already."""
     roots = list(exe.resolve().parents) + BUILD_DIRS
 
     for root in roots:
-        for suffix in OBJ_SUFFIXES:
-            candidate = root / NETPLAY_OBJ.parent / (NETPLAY_OBJ.name + suffix)
+        objects = root / "CMakeFiles"
 
-            if candidate.exists():
+        if not objects.is_dir():
+            continue
+
+        for suffix in OBJ_SUFFIXES:
+            for candidate in sorted(objects.glob(f"**/{NETPLAY_SOURCE}{suffix}")):
                 return candidate
 
     return None
@@ -173,7 +183,7 @@ def abandon(running: list) -> None:
 
 def explain(obj: Path, working_dir: Path) -> str:
     result = subprocess.run(
-        [sys.executable, str(REPO_ROOT / "tools" / "compare_states.py"), str(obj)],
+        [sys.executable, str(TOOLS_DIR / "compare_states.py"), str(obj)],
         cwd=working_dir,
         capture_output=True,
         text=True,
@@ -209,7 +219,7 @@ def main():
     args.obj = args.obj or find_obj(args.exe)
 
     if args.obj is None:
-        print(f"Could not find {NETPLAY_OBJ.name}.o near {args.exe}. Pass --obj.")
+        print(f"Could not find a built {NETPLAY_SOURCE} object near {args.exe}. Pass --obj.")
         return 1
 
     if not args.exe.exists():

--- a/tools/stress_desync.py
+++ b/tools/stress_desync.py
@@ -1,0 +1,190 @@
+"""Hunts for rollback desyncs and reports which state member caused them.
+
+Each run starts a GekkoNet stress session, which re-simulates the last
+--check-distance frames every update and compares the resulting checksums
+against the first pass. When they disagree, the game dumps both simulations of
+that frame into states/, and compare_states.py resolves the differing bytes to
+struct members.
+
+    python3 tools/stress_desync.py --seeds 20
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NETPLAY_OBJ = Path("CMakeFiles/3sx.dir/src/platform/netplay/netplay.c.obj")
+
+# build/stress is the optimised harness build; a Debug build works but is about
+# eight times slower, since every re-simulated frame copies and hashes the state.
+BUILD_DIRS = [REPO_ROOT / "build" / "stress", REPO_ROOT / "build"]
+
+
+def default_build() -> Path:
+    for build in BUILD_DIRS:
+        if (build / "application" / "bin" / "3sx.exe").exists():
+            return build
+
+    return BUILD_DIRS[-1]
+
+DESYNC_RE = re.compile(r"desync at frame (-?\d+) after (\d+) frames")
+TRACE_NAME = "stress-trace.log"
+
+# compare_states.py shells out to dwarfdump; MSYS2 only ships llvm-dwarfdump.
+DWARFDUMP_FALLBACKS = [Path("E:/MSYS2/mingw64/bin/llvm-dwarfdump.exe"), Path("/mingw64/bin/llvm-dwarfdump")]
+
+
+def prepare_run_dir(bin_dir: Path, seed: int) -> Path:
+    """Each seed gets its own directory so runs can go in parallel."""
+    run_dir = bin_dir / "stress-runs" / f"seed-{seed}"
+
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+
+    run_dir.mkdir(parents=True)
+
+    return run_dir
+
+
+def dwarfdump_env() -> dict:
+    env = dict(os.environ)
+
+    if "DWARFDUMP" in env or shutil.which("dwarfdump") or shutil.which("llvm-dwarfdump"):
+        return env
+
+    for candidate in DWARFDUMP_FALLBACKS:
+        if candidate.exists():
+            env["DWARFDUMP"] = str(candidate)
+            break
+
+    return env
+
+
+def start_session(exe: Path, run_dir: Path, seed: int, frames: int, check_distance: int) -> subprocess.Popen:
+    command = [
+        str(exe),
+        "--stress",
+        "--stress-seed", str(seed),
+        "--stress-out", str(run_dir),
+        "--no-sound",
+    ]
+
+    if frames:
+        command += ["--stress-frames", str(frames)]
+
+    if check_distance:
+        command += ["--stress-check-distance", str(check_distance)]
+
+    return subprocess.Popen(command, cwd=exe.parent, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def collect(process: subprocess.Popen, run_dir: Path, timeout: int) -> tuple[str, bool]:
+    """Waits for one session and returns its trace."""
+    timed_out = False
+
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+        timed_out = True
+
+    trace = run_dir / TRACE_NAME
+
+    return (trace.read_text(encoding="utf-8", errors="replace") if trace.exists() else "", timed_out)
+
+
+def explain(obj: Path, working_dir: Path) -> str:
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "tools" / "compare_states.py"), str(obj)],
+        cwd=working_dir,
+        capture_output=True,
+        text=True,
+        errors="replace",
+        env=dwarfdump_env(),
+    )
+
+    if result.returncode != 0:
+        return f"compare_states.py failed: {result.stderr.strip()}"
+
+    return result.stdout.strip() or "No byte differences found in the dumped states."
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find rollback desyncs and explain them.")
+    parser.add_argument("--exe", type=Path, help="Path to a netplay-enabled 3sx build.")
+    parser.add_argument("--obj", type=Path, help="Object file to read State debug info from.")
+    parser.add_argument("--seed", type=int, default=1, help="First seed to run.")
+    parser.add_argument("--seeds", type=int, default=1, help="How many consecutive seeds to run.")
+    parser.add_argument("--frames", type=int, default=0, help="Frame cap per seed (0 runs until a desync).")
+    parser.add_argument("--check-distance", type=int, default=0, help="Rollback depth (0 uses the game's default).")
+    parser.add_argument("--timeout", type=int, default=300, help="Seconds to allow per seed when uncapped.")
+    parser.add_argument("--jobs", type=int, default=1, help="How many sessions to run at once.")
+    parser.add_argument("--keep-going", action="store_true", help="Keep trying seeds after the first desync.")
+    args = parser.parse_args()
+
+    build = default_build()
+    args.exe = args.exe or build / "application" / "bin" / "3sx.exe"
+    args.obj = args.obj or build / NETPLAY_OBJ
+
+    if not args.exe.exists():
+        print(f"No build at {args.exe}. Build and install first.")
+        return 1
+
+    if not args.obj.exists():
+        print(f"No object file at {args.obj}. Build first, or pass --obj.")
+        return 1
+
+    # A stress frame costs about check_distance extra simulated frames, so this is
+    # far slower than realtime. Without a frame cap, cap the wall clock instead.
+    timeout = int(args.frames / 60 * 6) + 120 if args.frames else args.timeout
+    failures = 0
+
+    seeds = list(range(args.seed, args.seed + args.seeds))
+    cap = f"{args.frames} frames" if args.frames else f"until desync, {timeout}s cap"
+    jobs = max(1, args.jobs)
+
+    for wave_start in range(0, len(seeds), jobs):
+        wave = seeds[wave_start:wave_start + jobs]
+        print(f"=== seeds {wave[0]}-{wave[-1]} ({cap}) ===", flush=True)
+
+        running = []
+
+        for seed in wave:
+            run_dir = prepare_run_dir(args.exe.parent, seed)
+            running.append((seed, run_dir, start_session(args.exe, run_dir, seed, args.frames, args.check_distance)))
+
+        for seed, run_dir, process in running:
+            output, timed_out = collect(process, run_dir, timeout)
+
+            if timed_out:
+                print(f"seed {seed}: timed out after {timeout}s.")
+            elif "exiting:" not in output:
+                print(f"seed {seed}: exited without logging a reason - it may have crashed.")
+
+            desyncs = DESYNC_RE.findall(output)
+
+            if not desyncs:
+                print(f"seed {seed}: no desync.")
+                continue
+
+            failures += 1
+            frames = ", ".join(frame for frame, _ in desyncs)
+            print(f"seed {seed}: desync at frame(s) {frames}")
+            print(explain(args.obj, run_dir))
+
+        if failures and not args.keep_going:
+            break
+
+    print()
+    print(f"{failures} seed(s) desynced.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/stress_desync.py
+++ b/tools/stress_desync.py
@@ -18,7 +18,10 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-NETPLAY_OBJ = Path("CMakeFiles/3sx.dir/src/platform/netplay/netplay.c.obj")
+NETPLAY_OBJ = Path("CMakeFiles/3sx.dir/src/platform/netplay/netplay.c")
+
+# CMake suffixes objects with .obj on Windows and .o everywhere else.
+OBJ_SUFFIXES = [".obj", ".o"]
 
 # build/stress is the optimised harness build; a Debug build works but is about
 # eight times slower, since every re-simulated frame copies and hashes the state.
@@ -36,13 +39,27 @@ def exe_names() -> list[str]:
 
 
 def find_exe(build: Path) -> Path | None:
-    for name in exe_names():
-        candidate = build / "application" / "bin" / name
+    """A macOS bundle installs to the prefix itself, everything else to bin."""
+    prefix = build / "application"
 
-        if candidate.exists():
-            return candidate
+    for name in exe_names():
+        for candidate in (prefix / name, prefix / "bin" / name):
+            if candidate.exists():
+                return candidate
 
     return None
+
+
+def run_dir_for(exe: Path) -> Path:
+    """The game resolves its assets against the working directory, which for a
+    bundle is the directory holding the .app rather than the executable's own."""
+    exe = exe.resolve()
+
+    for parent in exe.parents:
+        if parent.suffix == ".app":
+            return parent.parent
+
+    return exe.parent
 
 
 def default_exe() -> Path | None:
@@ -82,12 +99,14 @@ def prepare_run_dir(bin_dir: Path, seed: int) -> Path:
 def find_obj(exe: Path) -> Path | None:
     """The object file sits in the build tree the executable was installed from,
     so walk up from it before falling back to the usual build directories."""
-    candidates = [parent / NETPLAY_OBJ for parent in exe.resolve().parents]
-    candidates += [build / NETPLAY_OBJ for build in BUILD_DIRS]
+    roots = list(exe.resolve().parents) + BUILD_DIRS
 
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
+    for root in roots:
+        for suffix in OBJ_SUFFIXES:
+            candidate = root / NETPLAY_OBJ.parent / (NETPLAY_OBJ.name + suffix)
+
+            if candidate.exists():
+                return candidate
 
     return None
 
@@ -124,7 +143,7 @@ def start_session(exe: Path, run_dir: Path, seed: int, frames: int, check_distan
     if check_distance:
         command += ["--stress-check-distance", str(check_distance)]
 
-    return subprocess.Popen(command, cwd=exe.parent, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return subprocess.Popen(command, cwd=run_dir_for(exe), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 def collect(process: subprocess.Popen, run_dir: Path, timeout: int) -> tuple[str, bool]:
@@ -190,7 +209,7 @@ def main():
     args.obj = args.obj or find_obj(args.exe)
 
     if args.obj is None:
-        print(f"Could not find {NETPLAY_OBJ.name} near {args.exe}. Pass --obj.")
+        print(f"Could not find {NETPLAY_OBJ.name}.o near {args.exe}. Pass --obj.")
         return 1
 
     if not args.exe.exists():
@@ -217,7 +236,7 @@ def main():
         running = []
 
         for seed in wave:
-            run_dir = prepare_run_dir(args.exe.parent, seed)
+            run_dir = prepare_run_dir(run_dir_for(args.exe), seed)
             running.append((seed, run_dir, start_session(args.exe, run_dir, seed, args.frames, args.check_distance)))
 
         for index, (seed, run_dir, process) in enumerate(running):

--- a/tools/stress_desync.py
+++ b/tools/stress_desync.py
@@ -25,18 +25,46 @@ NETPLAY_OBJ = Path("CMakeFiles/3sx.dir/src/platform/netplay/netplay.c.obj")
 BUILD_DIRS = [REPO_ROOT / "build" / "stress", REPO_ROOT / "build"]
 
 
-def default_build() -> Path:
-    for build in BUILD_DIRS:
-        if (build / "application" / "bin" / "3sx.exe").exists():
-            return build
+def exe_names() -> list[str]:
+    if sys.platform == "win32":
+        return ["3sx.exe"]
 
-    return BUILD_DIRS[-1]
+    if sys.platform == "darwin":
+        return ["3SX.app/Contents/MacOS/3SX", "3sx"]
+
+    return ["3sx"]
+
+
+def find_exe(build: Path) -> Path | None:
+    for name in exe_names():
+        candidate = build / "application" / "bin" / name
+
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
+def default_exe() -> Path | None:
+    """THREESX_EXE wins, as it does for tools/run-netplay-local.sh."""
+    override = os.environ.get("THREESX_EXE")
+
+    if override:
+        return Path(override)
+
+    for build in BUILD_DIRS:
+        found = find_exe(build)
+
+        if found:
+            return found
+
+    return None
 
 DESYNC_RE = re.compile(r"desync at frame (-?\d+) after (\d+) frames")
 TRACE_NAME = "stress-trace.log"
 
 # compare_states.py shells out to dwarfdump; MSYS2 only ships llvm-dwarfdump.
-DWARFDUMP_FALLBACKS = [Path("E:/MSYS2/mingw64/bin/llvm-dwarfdump.exe"), Path("/mingw64/bin/llvm-dwarfdump")]
+DWARFDUMP_NAMES = ["dwarfdump", "llvm-dwarfdump"]
 
 
 def prepare_run_dir(bin_dir: Path, seed: int) -> Path:
@@ -51,15 +79,31 @@ def prepare_run_dir(bin_dir: Path, seed: int) -> Path:
     return run_dir
 
 
+def find_obj(exe: Path) -> Path | None:
+    """The object file sits in the build tree the executable was installed from,
+    so walk up from it before falling back to the usual build directories."""
+    candidates = [parent / NETPLAY_OBJ for parent in exe.resolve().parents]
+    candidates += [build / NETPLAY_OBJ for build in BUILD_DIRS]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
 def dwarfdump_env() -> dict:
+    """compare_states.py reads DWARFDUMP, so resolve the tool off PATH for it."""
     env = dict(os.environ)
 
-    if "DWARFDUMP" in env or shutil.which("dwarfdump") or shutil.which("llvm-dwarfdump"):
+    if "DWARFDUMP" in env:
         return env
 
-    for candidate in DWARFDUMP_FALLBACKS:
-        if candidate.exists():
-            env["DWARFDUMP"] = str(candidate)
+    for name in DWARFDUMP_NAMES:
+        found = shutil.which(name)
+
+        if found:
+            env["DWARFDUMP"] = found
             break
 
     return env
@@ -128,9 +172,17 @@ def main():
     parser.add_argument("--keep-going", action="store_true", help="Keep trying seeds after the first desync.")
     args = parser.parse_args()
 
-    build = default_build()
-    args.exe = args.exe or build / "application" / "bin" / "3sx.exe"
-    args.obj = args.obj or build / NETPLAY_OBJ
+    args.exe = args.exe or default_exe()
+
+    if args.exe is None:
+        print("No build found. Pass --exe or set THREESX_EXE.")
+        return 1
+
+    args.obj = args.obj or find_obj(args.exe)
+
+    if args.obj is None:
+        print(f"Could not find {NETPLAY_OBJ.name} near {args.exe}. Pass --obj.")
+        return 1
 
     if not args.exe.exists():
         print(f"No build at {args.exe}. Build and install first.")

--- a/tools/stress_desync.py
+++ b/tools/stress_desync.py
@@ -143,6 +143,15 @@ def collect(process: subprocess.Popen, run_dir: Path, timeout: int) -> tuple[str
     return (trace.read_text(encoding="utf-8", errors="replace") if trace.exists() else "", timed_out)
 
 
+def abandon(running: list) -> None:
+    """One desync is enough to work with, so the rest of the wave is wasted."""
+    for _, _, process in running:
+        process.kill()
+
+    for _, _, process in running:
+        process.wait()
+
+
 def explain(obj: Path, working_dir: Path) -> str:
     result = subprocess.run(
         [sys.executable, str(REPO_ROOT / "tools" / "compare_states.py"), str(obj)],
@@ -211,7 +220,7 @@ def main():
             run_dir = prepare_run_dir(args.exe.parent, seed)
             running.append((seed, run_dir, start_session(args.exe, run_dir, seed, args.frames, args.check_distance)))
 
-        for seed, run_dir, process in running:
+        for index, (seed, run_dir, process) in enumerate(running):
             output, timed_out = collect(process, run_dir, timeout)
 
             if timed_out:
@@ -229,6 +238,10 @@ def main():
             frames = ", ".join(frame for frame, _ in desyncs)
             print(f"seed {seed}: desync at frame(s) {frames}")
             print(explain(args.obj, run_dir))
+
+            if not args.keep_going:
+                abandon(running[index + 1:])
+                break
 
         if failures and not args.keep_going:
             break


### PR DESCRIPTION
Rebased onto main now that #297 has merged.

Adds a stress session for finding rollback desyncs, then fixes what it found.

## The harness

`--stress` re-simulates the last `check_distance` frames every update and compares checksums against the first pass, so desyncs surface without a second peer. It drives the menus itself and starts at the fight. On a mismatch it dumps both simulations of the frame, and `tools/stress_desync.py` runs seeds and resolves the differing bytes to struct members.

```
python tools/stress_desync.py --seeds 16 --jobs 4
```

It lives in `netplay_stress.c` rather than in `netplay.c`, and runs headlessly through `sdl_stress_app.c` like the statcheck headless app, which makes it about nine times faster than a vsync-limited run. A campaign stops at the first desync; `--keep-going` runs every seed.

## Findings

| Cause | Effect | Fix |
| --- | --- | --- |
| `Present_Mode` is `u8` in `GameState` but a 4 byte enum as a global, so copies spilled into `Play_Mode`/`Page_Max` | Restored as `0x101`, so `save_w[Present_Mode]` read out of bounds and the pad mapping turned to garbage. Desynced on the first rollback of every match | Match the global's type |
| `chainex_check` (EX moves used) never saved | Flags survived the rollback, so the re-simulation refused a move it had just performed | Save it |
| `Random_ix16_bg` saved, but not the state deciding when to draw from it | Re-simulation consulted the table a different number of times, disagreeing over stage flashing | Leave the index out |
| Replay recorder's `Demo_Ptr` never saved | Re-simulated frames recorded again, so the buffer filled early and `Replay_Status` flipped at a different frame per side. Desynced 30s into every match | Save the write pointer |
| Menu state carried into a P2P session (`E_No`, attract counters, layer works) | Peers started from different states, so the checksum never agreed. The fight stayed in sync, so nothing showed on screen | Reset in `setup_vs_mode` |
| `bg_w.scno` left at 3 by the attract sequence, and only set by the stage on frame 2 | Peers reaching the menu at different times disagreed for frames 0 and 1, then converged | Reset it too |
| `my_clear_level` assigned past the `No_Trans` guard in `Mtrans_use_trans_mode`, making it part of drawing | Rollback re-simulates without drawing, so the first pass wrote `0x90` and the re-simulation kept the old value | Assign it before the guard |
| `OK_Appear79` and `Extra_Counter` never saved, though every other super art select global is | Both gate `routine_no` in `eff79`, and `Extra_Counter` survives between matches, so a rollback in one super art select desynced the next | Save them |

Two would have desynced real netplay on the first rollback, and `Present_Mode` is also an out of bounds read.

`my_clear_level` only feeds rendering, but the checksum covers the state saved after every advance including rolled back ones, so peers rolling back different amounts reported a desync where nothing diverged. Excluding it would mean zeroing one `s16` inside the wholesale `plw` copy, which is otherwise pure simulation state.

## Guards

- `GS_SAVE`/`GS_LOAD` and `SDL_copya` assert at compile time that each field matches its global. All 567 members pass, so this only fences off the mistake.
- The dump refuses to write a frame whose buffer slot has been reused, rather than comparing two unrelated frames.
- A run ends when the match does. The texture cache is not saved and the post match screens release and reload it, so rolling back across that boundary drew a player from a freed MTS slot and aborted.

## Verification

- Seeds 1 to 250 clean, no timeouts or crashes, at the default rollback depth and running until each match ends.
- Reintroducing the `chainex_check` fix as a bug desyncs 4 of 4 seeds, and the diff resolves to the state it corrupts, so detection and diagnosis are both exercised.
- P2P: a local two instance session went from desyncing every frame, to frames 0 and 1, to none. Three consecutive matches with a character change now complete without a dump.

## Not covered

Cross machine desyncs from floating point or compiler differences still need a real two peer match.

The session starts at the fight while real netplay starts at character select, so earlier screens are out of reach. The `eff79` desync was found in a real match for that reason.

An unsaved field never appears in the diff itself, since it is identical in both dumps. Only the state it corrupts does.

`Demo_Ptr` is a raw pointer, which is fine in process but would need to be an offset if the state is ever sent to a peer.
