### PR TITLE
Fix replay desyncs

### DIFF
--- a/src/sf33rd/Source/Game/animation/win_pl.c
+++ b/src/sf33rd/Source/Game/animation/win_pl.c
@@ -93,6 +93,10 @@ void Win_01000(PLW* wk) {
 
     bg_app_stop = 1;
 
+    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+    }
+
     switch (wk->wu.routine_no[3]) {
     case 0:
         win_rno[0] = win_rno[1] = 0;
@@ -360,10 +364,6 @@ void Win_03000(PLW* wk) {
 
     bg_app_stop = 1;
 
-    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
-    }
-
     switch (wk->wu.routine_no[3]) {
     case 0:
         wk->wu.routine_no[3]++;
@@ -478,7 +478,6 @@ void Normal_normal_Winner(PLW* wk) {
         char_move(&wk->wu);
         break;
     }
-
 }
 
 void Judge_normal_winner(PLW* wk) {
@@ -509,6 +508,10 @@ void Win_05000(PLW* wk) {
     s16 work;
 
     bg_app_stop = 1;
+
+    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+    }
 
     switch (wk->wu.routine_no[3]) {
     case 0:
@@ -561,10 +564,6 @@ void Win_05000(PLW* wk) {
             char_move(&wk->wu);
             break;
         }
-    }
-
-    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
     }
 }
 
@@ -690,8 +689,10 @@ void Win_08000(PLW* wk) {
 
         if (Round_Result & 0x800) {
             set_char_move_init(&wk->wu, 9, 40);
-        } else if (Round_num >= (save_w[Present_Mode].Battle_Number[Play_Type] * 2) ||
-                   PL_Wins[wk->wu.id] >= save_w[Present_Mode].Battle_Number[Play_Type] + 1) {
+        } else if (
+            Round_num >= (save_w[Present_Mode].Battle_Number[Play_Type] * 2) ||
+            PL_Wins[wk->wu.id] >= save_w[Present_Mode].Battle_Number[Play_Type] + 1
+        ) {
             work = win_select(wk, 3);
             set_char_move_init(&wk->wu, 9, work + 36);
         } else {

--- a/src/sf33rd/Source/Game/engine/cmd_main.c
+++ b/src/sf33rd/Source/Game/engine/cmd_main.c
@@ -74,14 +74,19 @@ void cmd_data_set(PLW* /* unused */, s16 i) { // 🟡
     }
 }
 
-void cmd_init(PLW* pl) { // 🟢
+void cmd_init(PLW* pl) { // 🟡
     s16 i;
     s16 j;
 
     cmd_id = pl->wu.id;
     pl->cp = &wcp[cmd_id];
 
-    SDL_zeroa(waza_work[cmd_id]);
+    if (ArcadeBalance_IsEnabled()) {
+        // CPS3 clears 0x540 bytes of each 0x620-byte command-state block, leaving entries 48-55 intact.
+        SDL_memset(waza_work[cmd_id], 0, sizeof(WAZA_WORK) * 48);
+    } else {
+        SDL_zeroa(waza_work[cmd_id]);
+    }
 
     for (i = 0; i < 56; i++) {
         wcp[cmd_id].waza_flag[i] = 0;

--- a/src/test/test_runner_compare.c
+++ b/src/test/test_runner_compare.c
@@ -1,10 +1,13 @@
 #if STATCHECK
 
 #include "test/test_runner_compare.h"
+#include "arcade/arcade_cmd_data.h"
 #include "arcade/arcade_constants.h"
 #include "args.h"
 #include "constants.h"
 #include "sf33rd/Source/Game/engine/cmb_win.h"
+#include "sf33rd/Source/Game/engine/cmd_data.h"
+#include "sf33rd/Source/Game/engine/cmd_main.h"
 #include "sf33rd/Source/Game/engine/plcnt.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
 #include "sf33rd/Source/Game/ui/count.h"
@@ -478,11 +481,10 @@ static void sync_wcp(WORK_CP* dst, const WORK_CP* src) {
     }
 }
 
-static void sync_waza_work(WAZA_WORK* dst, const WAZA_WORK* src, Character character) {
-    if (dst->w_type == 15 && character == CHAR_URIEN) {
-        dst->w_int = src->w_int;
-        dst->uni0.tame.flag = src->uni0.tame.flag;
-    }
+static void sync_waza_work(WAZA_WORK* dst, const WAZA_WORK* src) {
+    s16* local_w_ptr = dst->w_ptr;
+    *dst = *src;
+    dst->w_ptr = local_w_ptr;
 }
 
 void sync_values(SDL_IOStream* io) {
@@ -492,21 +494,27 @@ void sync_values(SDL_IOStream* io) {
     // WORK_CP wcp_cps3[2];
     // read_wcp(io, wcp_cps3);
 
-    // WAZA_WORK waza_work_cps3[2][56];
-    // read_waza_work(io, waza_work_cps3);
+    WAZA_WORK waza_work_cps3[2][56];
+    read_waza_work(io, waza_work_cps3);
 
     // T_PL_LVR t_pl_lvr_cps3[2];
     // read_t_pl_lvr(io, t_pl_lvr_cps3);
 
     for (int i = 0; i < 2; i++) {
-        const Character character = plw[i].player_number;
+        const Character character = CHAR_ARCADE_TO_3SX(read_u8(io, MY_CHAR_OFFSET + i));
 
         // sync_lvr(&t_pl_lvr[i], &t_pl_lvr_cps3[i]);
         // sync_wcp(&wcp[i], &wcp_cps3[i]);
 
-        // for (int j = 0; j < 56; j++) {
-        //     sync_waza_work(&waza_work[i][j], &waza_work_cps3[i][j], character);
-        // }
+        // CPS3's partial cmd_init clear preserves these entries across the transition. Rebuild their local
+        // command pointers, then synchronize the serialized parser state captured before the first round.
+
+        intptr_t* commands = (intptr_t*)ArcadeCommandData_Get(character);
+
+        for (int j = 48; j < pl_cmd_num[character][6]; j++) {
+            waza_compel_init(i, j, commands);
+            sync_waza_work(&waza_work[i][j], &waza_work_cps3[i][j]);
+        }
     }
 }
 


### PR DESCRIPTION
- Fixed Sean's position during his win animation
- Fixed desyncs in Twelve matches caused by a bug in arcade version: `cmd_init` doesn't clear the tail end of `waza_work`, which leads to command state being incorrectly preserved in non-interactive sequences (round start, round transition, etc.)