### PR TITLE
Reorder set_field_hosei_flag calls

### DIFF
--- a/src/sf33rd/Source/Game/animation/win_pl.c
+++ b/src/sf33rd/Source/Game/animation/win_pl.c
@@ -325,6 +325,10 @@ void Win_02000(PLW* wk) {
 
     switch (wk->wu.routine_no[3]) {
     case 0:
+        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+        }
+
         wk->wu.routine_no[3]++;
 
         win_rno[0] = win_rno[1] = 0;
@@ -341,10 +345,6 @@ void Win_02000(PLW* wk) {
             }
         } else {
             set_char_move_init(&wk->wu, 9, 32);
-        }
-
-        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
         }
 
         break;
@@ -404,7 +404,6 @@ void Win_03000(PLW* wk) {
         char_move(&wk->wu);
         break;
     }
-
 }
 
 void Win_04000(PLW* wk) {
@@ -412,6 +411,10 @@ void Win_04000(PLW* wk) {
     s16 work2;
 
     bg_app_stop = 1;
+
+    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+    }
 
     switch (wk->wu.routine_no[3]) {
     case 0:
@@ -451,10 +454,6 @@ void Win_04000(PLW* wk) {
         char_move(&wk->wu);
         break;
     }
-
-    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
-    }
 }
 
 void Normal_normal_Winner(PLW* wk) {
@@ -485,6 +484,10 @@ void Judge_normal_winner(PLW* wk) {
 
     bg_app_stop = 1;
 
+    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+    }
+
     switch (wk->wu.routine_no[3]) {
     case 0:
         win_rno[0] = win_rno[1] = 0;
@@ -497,10 +500,6 @@ void Judge_normal_winner(PLW* wk) {
     case 9:
         char_move(&wk->wu);
         break;
-    }
-
-    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
     }
 }
 
@@ -574,6 +573,10 @@ void Win_06000(PLW* wk) {
 
     switch (wk->wu.routine_no[3]) {
     case 0:
+        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+        }
+
         win_rno[0] = win_rno[1] = 0;
         wk->wu.routine_no[3]++;
 
@@ -584,10 +587,6 @@ void Win_06000(PLW* wk) {
         } else {
             work = win_select(wk, 3);
             set_char_move_init(&wk->wu, 9, work + 32);
-        }
-
-        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
         }
 
         break;
@@ -602,6 +601,10 @@ void Win_07000(PLW* wk) {
     s16 work;
 
     bg_app_stop = 1;
+
+    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+    }
 
     switch (wk->wu.routine_no[3]) {
     case 0:
@@ -671,10 +674,6 @@ void Win_07000(PLW* wk) {
             char_move(&wk->wu);
         }
     }
-
-    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
-    }
 }
 
 void Win_08000(PLW* wk) {
@@ -684,6 +683,10 @@ void Win_08000(PLW* wk) {
 
     switch (wk->wu.routine_no[3]) {
     case 0:
+        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+        }
+
         win_rno[0] = win_rno[1] = 0;
         wk->wu.routine_no[3]++;
 
@@ -700,10 +703,6 @@ void Win_08000(PLW* wk) {
             set_char_move_init(&wk->wu, 9, work + 32);
         }
 
-        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
-        }
-
         break;
 
     default:
@@ -716,6 +715,10 @@ void Win_09000(PLW* wk) {
     s16 work;
 
     bg_app_stop = 1;
+
+    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+    }
 
     switch (wk->wu.routine_no[3]) {
     case 0:
@@ -789,10 +792,6 @@ void Win_09000(PLW* wk) {
         Normal_normal_Winner(wk);
         break;
     }
-
-    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
-    }
 }
 
 void Win_10000(PLW* wk) {
@@ -807,6 +806,10 @@ void Win_10000(PLW* wk) {
 
     switch (wk->wu.routine_no[3]) {
     case 0:
+        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+        }
+
         win_rno[0] = win_rno[1] = 0;
         wk->wu.routine_no[3]++;
         work = win_select(wk, 3);
@@ -844,10 +847,6 @@ void Win_10000(PLW* wk) {
             }
         } else {
             set_char_move_init(&wk->wu, 9, work + 32);
-        }
-
-        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
         }
 
         break;
@@ -1103,6 +1102,10 @@ void Win_11000(PLW* wk) {
 
     switch (wk->wu.routine_no[3]) {
     case 0:
+        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+        }
+
         win_rno[0] = win_rno[1] = 0;
         wk->wu.routine_no[3]++;
         work = win_select(wk, 3);
@@ -1132,10 +1135,6 @@ void Win_11000(PLW* wk) {
         } else {
             win_rno[0] = 0;
             set_char_move_init(&wk->wu, 9, work + 32);
-        }
-
-        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
         }
 
         break;
@@ -1308,6 +1307,10 @@ void Win_13000(PLW* wk) {
 
     switch (wk->wu.routine_no[3]) {
     case 0:
+        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+        }
+
         win_rno[0] = win_rno[1] = 0;
         wk->wu.routine_no[3]++;
 
@@ -1330,10 +1333,6 @@ void Win_13000(PLW* wk) {
             set_char_move_init(&wk->wu, 9, work + 32);
         }
 
-        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
-        }
-
         break;
 
     default:
@@ -1346,6 +1345,10 @@ void Win_14000(PLW* wk) {
     s16 work;
 
     bg_app_stop = 1;
+
+    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+    }
 
     switch (wk->wu.routine_no[3]) {
     case 0:
@@ -1376,10 +1379,6 @@ void Win_14000(PLW* wk) {
         }
 
         break;
-    }
-
-    if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-        set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
     }
 }
 
@@ -1490,6 +1489,10 @@ void Win_15000(PLW* wk) {
 
     switch (wk->wu.routine_no[3]) {
     case 0:
+        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
+            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
+        }
+
         win_rno[0] = win_rno[1] = 0;
         wk->wu.routine_no[3]++;
 
@@ -1500,10 +1503,6 @@ void Win_15000(PLW* wk) {
         } else {
             work = win_select(wk, 3);
             set_char_move_init(&wk->wu, 9, work + 32);
-        }
-
-        if (set_field_hosei_flag(&plw[wk->wu.id], scrr, 1)) {
-            set_field_hosei_flag(&plw[wk->wu.id], scrl, 0);
         }
 
         break;
@@ -1522,6 +1521,14 @@ s16 win_select(PLW* /* unused */, s16 num) {
 
 void bonus_game_win_pause(PLW* wk) {
     bg_app_stop = 1;
+
+    if (set_field_hosei_flag(&plw[1], bs_scrrrl[1][0], 1)) {
+        set_field_hosei_flag(&plw[1], bs_scrrrl[1][1], 0);
+    }
+
+    if (set_field_hosei_flag(&plw[0], bs_scrrrl[0][0], 1)) {
+        set_field_hosei_flag(&plw[0], bs_scrrrl[0][1], 0);
+    }
 
     switch (wk->wu.routine_no[3]) {
     case 0:
@@ -1582,14 +1589,6 @@ void bonus_game_win_pause(PLW* wk) {
     case 9:
         char_move(&wk->wu);
         break;
-    }
-
-    if (set_field_hosei_flag(&plw[1], bs_scrrrl[1][0], 1)) {
-        set_field_hosei_flag(&plw[1], bs_scrrrl[1][1], 0);
-    }
-
-    if (set_field_hosei_flag(&plw[0], bs_scrrrl[0][0], 1)) {
-        set_field_hosei_flag(&plw[0], bs_scrrrl[0][1], 0);
     }
 }
 


### PR DESCRIPTION
Adjusted order of most calls to `set_field_hosei_flag`. This prevents Statcheck runs from de-syncing because win animation position clamping near the wall