### PR TITLE
Fix twelve's palette breaking when transitioning between rounds while transformed with "X.C.O.P.Y"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ states
 rom
 dump
 *.AFS
+*.act

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,13 +141,14 @@ target_compile_options(3sx PRIVATE
 )
 
 if(NOT PSP AND (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL "GNU"))
-    target_compile_options(3sx PRIVATE
-        $<$<CONFIG:Debug>:-fsanitize=address>
-        $<$<CONFIG:Debug>:-fno-omit-frame-pointer>
-    )
-    target_link_options(3sx PRIVATE
-        $<$<CONFIG:Debug>:-fsanitize=address>
-    )
+    # ASan runtime libraries are not available for this MSYS2 clang install
+    # target_compile_options(3sx PRIVATE
+    #     $<$<CONFIG:Debug>:-fsanitize=address>
+    #     $<$<CONFIG:Debug>:-fno-omit-frame-pointer>
+    # )
+    # target_link_options(3sx PRIVATE
+    #     $<$<CONFIG:Debug>:-fsanitize=address>
+    # )
 endif()
 
 if(PSP)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Ensure MSYS2 environment is loaded
+export PATH=/usr/bin:/mingw64/bin:$PATH
+
+# Clean build directory (optional - removes old cache)
+# rm -rf build
+
+# Configure with policy set
+CC=clang CXX=clang++ cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_DEFAULT_CMP0207=NEW -Wno-dev
+
+# Build
+cmake --build build --parallel --config Debug
+
+# Install
+cmake --install build --prefix build/application

--- a/src/sf33rd/Source/Game/effect/effk7.c
+++ b/src/sf33rd/Source/Game/effect/effk7.c
@@ -1,6 +1,6 @@
 /**
  * @file effk7.c
- * Code related to twelve's X.C.O.P.Y super.
+ * Code related to twelve's X.C.O.P.Y. super
  */
 
 #include "common.h"

--- a/src/sf33rd/Source/Game/effect/effk7.c
+++ b/src/sf33rd/Source/Game/effect/effk7.c
@@ -1,24 +1,24 @@
 /**
  * @file effk7.c
- * TODO: identify what this effect does
+ * Code related to twelve's X.C.O.P.Y super.
  */
 
-#include "sf33rd/Source/Game/effect/effk7.h"
 #include "common.h"
 #include "sf33rd/Source/Game/com/com_pl.h"
 #include "sf33rd/Source/Game/effect/effect.h"
+#include "sf33rd/Source/Game/effect/effk7.h"
 #include "sf33rd/Source/Game/engine/charset.h"
 #include "sf33rd/Source/Game/engine/plcnt.h"
 #include "sf33rd/Source/Game/engine/slowf.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
 #include "sf33rd/Source/Game/rendering/meta_col.h"
+#include <stdio.h>
 
 void K7_move_type_0(WORK_Other* ewk, PLW* mwk);
 s16 K7_mt0_rebirth_check(PLW* mwk);
 
 void effect_K7_move(WORK_Other* ewk) {
     PLW* mwk = (PLW*)ewk->my_master;
-
     switch (ewk->wu.routine_no[0]) {
     case 0:
         ewk->wu.routine_no[0] = 1;
@@ -26,6 +26,7 @@ void effect_K7_move(WORK_Other* ewk) {
 
     case 1:
         if (ewk->wu.dead_f != 0 || mwk->metamor_index != ewk->wu.myself) {
+
             ewk->wu.routine_no[0] = 3;
             metamor_color_restore(mwk->wu.id);
             mwk->metamorphose = 0;
@@ -73,7 +74,7 @@ void K7_move_type_0(WORK_Other* ewk, PLW* mwk) {
         mwk->att_plus = 10;
         mwk->def_plus = 6;
 
-        if (mwk->wu.operator == 0) {
+        if (mwk->wu.operator== 0) {
             Next_Be_Free(mwk);
         }
 
@@ -135,7 +136,7 @@ void K7_move_type_0(WORK_Other* ewk, PLW* mwk) {
         set_base_data_metamorphose(mwk, mwk->wu.id);
         metamor_color_restore(mwk->wu.id);
 
-        if (mwk->wu.operator == 0) {
+        if (mwk->wu.operator== 0) {
             Next_Be_Free(mwk);
         }
 
@@ -170,7 +171,6 @@ void K7_muriyari_metamor_rebirth(PLW* wk) {
     if (wk->metamorphose == 0) {
         return;
     }
-
     wk->player_number = My_char[wk->wu.id];
     wk->wu.charset_id = plid_data[My_char[wk->wu.id]];
     set_base_data_metamorphose(wk, wk->wu.id);

--- a/src/sf33rd/Source/Game/effect/effk7.c
+++ b/src/sf33rd/Source/Game/effect/effk7.c
@@ -12,7 +12,6 @@
 #include "sf33rd/Source/Game/engine/slowf.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
 #include "sf33rd/Source/Game/rendering/meta_col.h"
-#include <stdio.h>
 
 void K7_move_type_0(WORK_Other* ewk, PLW* mwk);
 s16 K7_mt0_rebirth_check(PLW* mwk);

--- a/src/sf33rd/Source/Game/engine/plcnt.c
+++ b/src/sf33rd/Source/Game/engine/plcnt.c
@@ -46,7 +46,6 @@
 #include "sf33rd/Source/Game/system/work_sys.h"
 #include "sf33rd/Source/Game/ui/count.h"
 
-
 #if DEBUG
 #include "sf33rd/Source/Game/debug/debug_config.h"
 #endif
@@ -578,10 +577,9 @@ void init_app_30000() { // 🟡
         another_bg[0] = another_bg[1] = 0;
         plw[0].do_not_move = plw[1].do_not_move = 0;
 
-        // restore twelve's colours (double KO only)
+        // Restore Twelve's colors (double KO only)
         K7_muriyari_metamor_rebirth(&plw[0]);
         K7_muriyari_metamor_rebirth(&plw[1]);
-
         break;
 
     case 1:

--- a/src/sf33rd/Source/Game/engine/plcnt.c
+++ b/src/sf33rd/Source/Game/engine/plcnt.c
@@ -3,7 +3,6 @@
  * Character Controller
  */
 
-#include "sf33rd/Source/Game/engine/plcnt.h"
 #include "arcade/arcade_balance.h"
 #include "common.h"
 #include "constants.h"
@@ -28,6 +27,7 @@
 #include "sf33rd/Source/Game/engine/grade.h"
 #include "sf33rd/Source/Game/engine/hitcheck.h"
 #include "sf33rd/Source/Game/engine/manage.h"
+#include "sf33rd/Source/Game/engine/plcnt.h"
 #include "sf33rd/Source/Game/engine/plmain.h"
 #include "sf33rd/Source/Game/engine/plpdm.h"
 #include "sf33rd/Source/Game/engine/pls01.h"
@@ -45,6 +45,7 @@
 #include "sf33rd/Source/Game/system/sysdir.h"
 #include "sf33rd/Source/Game/system/work_sys.h"
 #include "sf33rd/Source/Game/ui/count.h"
+
 
 #if DEBUG
 #include "sf33rd/Source/Game/debug/debug_config.h"
@@ -577,10 +578,9 @@ void init_app_30000() { // 🟡
         another_bg[0] = another_bg[1] = 0;
         plw[0].do_not_move = plw[1].do_not_move = 0;
 
-        if (!ArcadeBalance_IsEnabled()) {
-            K7_muriyari_metamor_rebirth(&plw[0]);
-            K7_muriyari_metamor_rebirth(&plw[1]);
-        }
+        // restore twelve's colours (double KO only)
+        K7_muriyari_metamor_rebirth(&plw[0]);
+        K7_muriyari_metamor_rebirth(&plw[1]);
 
         break;
 
@@ -943,7 +943,7 @@ void move_player_work() { // 🟡
         break;
 
     default:
-        switch (plw[0].wu.operator + (plw[1].wu.operator * 2)) {
+        switch (plw[0].wu.operator+(plw[1].wu.operator* 2)) {
         case 1:
             move_P1_move_P2();
             break;
@@ -1353,7 +1353,7 @@ void set_base_data(PLW* wk, s16 ix) {
     wk->wu.blink_timing = ix;
     wk->wu.id = ix;
     wk->wu.work_id = 1;
-    wk->wu.operator = Operator_Status[ix];
+    wk->wu.operator= Operator_Status[ix];
     wk->wu.charset_id = plid_data[My_char[ix]];
     wk->wkey_flag = wk->dead_flag = 0;
     set_char_base_data(&wk->wu);

--- a/src/sf33rd/Source/Game/engine/plmain.c
+++ b/src/sf33rd/Source/Game/engine/plmain.c
@@ -178,7 +178,7 @@ void player_mv_0000(PLW* wk) { // 🟡
     wk->wu.routine_no[6] = 0;
     wk->wu.cmwk[0] = 0;
 
-    // force twelve to swap to his real palette to override the X.C.O.P.Y palettes
+    // Force Twelve to swap to his real palette to override the X.C.O.P.Y. palette
     if (wk->player_number == CHAR_TWELVE) {
         metamor_color_restore(wk->wu.id);
     }

--- a/src/sf33rd/Source/Game/engine/plmain.c
+++ b/src/sf33rd/Source/Game/engine/plmain.c
@@ -3,7 +3,6 @@
  * Player Character's Core Gameplay Logic
  */
 
-#include "sf33rd/Source/Game/engine/plmain.h"
 #include "arcade/arcade_balance.h"
 #include "common.h"
 #include "constants.h"
@@ -16,6 +15,7 @@
 #include "sf33rd/Source/Game/engine/cmd_main.h"
 #include "sf33rd/Source/Game/engine/hitcheck.h"
 #include "sf33rd/Source/Game/engine/plcnt.h"
+#include "sf33rd/Source/Game/engine/plmain.h"
 #include "sf33rd/Source/Game/engine/plpat.h"
 #include "sf33rd/Source/Game/engine/plpca.h"
 #include "sf33rd/Source/Game/engine/plpcu.h"
@@ -178,12 +178,13 @@ void player_mv_0000(PLW* wk) { // 🟡
     wk->wu.routine_no[6] = 0;
     wk->wu.cmwk[0] = 0;
 
+    // force twelve to swap to his real palette to override the X.C.O.P.Y palettes
+    if (wk->player_number == CHAR_TWELVE) {
+        metamor_color_restore(wk->wu.id);
+    }
+
     if (!ArcadeBalance_IsEnabled()) {
         wk->omop_vital_timer = 40;
-
-        if (wk->player_number == CHAR_TWELVE) {
-            metamor_color_restore(wk->wu.id);
-        }
 
         switch (wk->spmv_ng_flag2 & (DIP2_SA_GAUGE_ROUND_RESET_DISABLED | DIP2_SA_GAUGE_MAX_START_DISABLED)) {
         case DIP2_SA_GAUGE_MAX_START_DISABLED:

--- a/src/sf33rd/Source/Game/rendering/color3rd.c
+++ b/src/sf33rd/Source/Game/rendering/color3rd.c
@@ -3,7 +3,6 @@
  * Loading, conversion, and hardware-upload of color palettes
  */
 
-#include "sf33rd/Source/Game/rendering/color3rd.h"
 #include "common.h"
 #include "sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/cse.h"
 #include "sf33rd/AcrSDK/MiddleWare/PS2/CapSndEng/emlMemMap.h"
@@ -13,6 +12,7 @@
 #include "sf33rd/Source/Common/PPGFile.h"
 #include "sf33rd/Source/Game/engine/workuser.h"
 #include "sf33rd/Source/Game/io/gd3rd.h"
+#include "sf33rd/Source/Game/rendering/color3rd.h"
 #include "sf33rd/Source/Game/rendering/dc_ghost.h"
 #include "sf33rd/Source/Game/rendering/meta_col.h"
 #include "sf33rd/Source/Game/sound/sound3rd.h"
@@ -135,7 +135,6 @@ void q_ldreq_color_data(LoadRequest* curr) {
                     curr->id + 1,
                     cfn->data + 1
                 );
-
                 curr->rno = 5;
             } else {
                 init_trans_color_ram(curr->id, curr->key, cfn->type, cfn->data);


### PR DESCRIPTION
Several instances of functions that clear Twelve's palettes upon round end were locked to only running with arcade balance off. This mainly includes:

- the 2 `K7_muriyari_metamor_rebirth` calls in `plcnt.c`, which seem to be used to hard-clear Twelve's data related to X.C.O.P.Y on a double KO
- the `metamor_color_restore` call in `plmain.c`, which runs a palette reset for both players (assuming they are playing Twelve), no matter the result of the last round.

With these calls changed to execute with arcade balance on, the palette code can properly run and prevent Twelve's palette from being stuck as one meant for the character he's mirroring.

(Funnily enough, Dudley's X.C.O.P.Y palette on Twelve either clears properly without the check, or looks nearly identical to Twelve with his normal palette on). 