### PR TITLE
Fix twelve's palette breaking when transitioning between rounds while transformed with "X.C.O.P.Y"

### DIFF
--- a/src/sf33rd/Source/Game/effect/effk7.c
+++ b/src/sf33rd/Source/Game/effect/effk7.c
@@ -1,6 +1,6 @@
 /**
  * @file effk7.c
- * TODO: identify what this effect does
+ * Code related to twelve's X.C.O.P.Y. super
  */
 
 #include "sf33rd/Source/Game/effect/effk7.h"

--- a/src/sf33rd/Source/Game/engine/plcnt.c
+++ b/src/sf33rd/Source/Game/engine/plcnt.c
@@ -577,11 +577,9 @@ void init_app_30000() { // 🟡
         another_bg[0] = another_bg[1] = 0;
         plw[0].do_not_move = plw[1].do_not_move = 0;
 
-        if (!ArcadeBalance_IsEnabled()) {
-            K7_muriyari_metamor_rebirth(&plw[0]);
-            K7_muriyari_metamor_rebirth(&plw[1]);
-        }
-
+        // Restore Twelve's colors (double KO only)
+        K7_muriyari_metamor_rebirth(&plw[0]);
+        K7_muriyari_metamor_rebirth(&plw[1]);
         break;
 
     case 1:

--- a/src/sf33rd/Source/Game/engine/plmain.c
+++ b/src/sf33rd/Source/Game/engine/plmain.c
@@ -178,12 +178,13 @@ void player_mv_0000(PLW* wk) { // 🟡
     wk->wu.routine_no[6] = 0;
     wk->wu.cmwk[0] = 0;
 
+    // Force Twelve to swap to his real palette to override the X.C.O.P.Y. palette
+    if (wk->player_number == CHAR_TWELVE) {
+        metamor_color_restore(wk->wu.id);
+    }
+
     if (!ArcadeBalance_IsEnabled()) {
         wk->omop_vital_timer = 40;
-
-        if (wk->player_number == CHAR_TWELVE) {
-            metamor_color_restore(wk->wu.id);
-        }
 
         switch (wk->spmv_ng_flag2 & (DIP2_SA_GAUGE_ROUND_RESET_DISABLED | DIP2_SA_GAUGE_MAX_START_DISABLED)) {
         case DIP2_SA_GAUGE_MAX_START_DISABLED:


### PR DESCRIPTION
Several instances of functions that clear Twelve's palettes upon round end were locked to only running with arcade balance off. This mainly includes:

- the 2 `K7_muriyari_metamor_rebirth` calls in `plcnt.c`, which seem to be used to hard-clear Twelve's data related to X.C.O.P.Y on a double KO
- the `metamor_color_restore` call in `plmain.c`, which runs a palette reset for both players (assuming they are playing Twelve), no matter the result of the last round.

With these calls changed to execute with arcade balance on, the palette code can properly run and prevent Twelve's palette from being stuck as one meant for the character he's mirroring.

(Funnily enough, Dudley's X.C.O.P.Y palette on Twelve either clears properly without the check, or looks nearly identical to Twelve with his normal palette on). 