### PR TITLE
Fix objects overlapping HUD when draw-players-over-hud is enabled

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -23,13 +23,14 @@ The way the internal 384x224 buffer is scaled.
 
 #### `nearest` (default)
 
-Produces sharp pixels at the cost of sizing consistency
+Produces sharp pixels at the cost of sizing consistency.
 
 #### `integer`
 
-Produces a pixel-perfect image, but requires a 4K display
+Produces a pixel-perfect image, but requires a 4K display.
 
-> ⚠️ WARNING: the image is gonna be cropped if your display resolution is smaller than 2688x2016
+> [!WARNING] 
+> The image is gonna be cropped if your display resolution is smaller than 2688x2016.
 
 #### `square-pixels`
 
@@ -41,8 +42,20 @@ Defines the strength of the scanline filter (from `0` to `100`). `0` means the f
 
 ### `draw-players-above-hud`
 
-Allow characters to render in front of the top HUD similar to Street Fighter IV. May introduce visual abnormalities on certain stages.
+Allow characters to render in front of the top HUD similar to Street Fighter IV.
 
-### `arcade-balance` (experimental)
+> [!NOTE]
+> With this setting on these stage decorations will be disabled to prevent overlapping with HUD:
+> - Chun-Li's stage: Bamboo stick on the right
+> - Makoto's stage: Tree on the right
+> - Yang's stage: Rain overlay
 
-Enables arcade balance instead of PS2 balance (work in progress). Requires `sfiii3nr1.zip` to be present in [`resources`](resources.md) directory.
+### `arcade-balance`
+
+Enables arcade balance instead of PS2 balance. 
+
+> [!IMPORTANT]
+> Requires `sfiii3nr1.zip` to be present in [`resources`](resources.md) directory.
+
+> [!WARNING]
+> Arcade balance is a work-in-progress. Expect bugs, crashes and instability when enabling this feature.

--- a/src/sf33rd/Source/Game/effect/eff05.c
+++ b/src/sf33rd/Source/Game/effect/eff05.c
@@ -1,6 +1,6 @@
 /**
  * @file eff05.c
- * TODO: identify what this effect does
+ * Stage background objects
  */
 
 #include "sf33rd/Source/Game/effect/eff05.h"

--- a/src/sf33rd/Source/Game/effect/eff06.c
+++ b/src/sf33rd/Source/Game/effect/eff06.c
@@ -1,10 +1,11 @@
 /**
  * @file eff06.c
- * TODO: identify what this effect does
+ * Stage background objects
  */
 
 #include "sf33rd/Source/Game/effect/eff06.h"
 #include "common.h"
+#include "port/config/config.h"
 #include "sf33rd/Source/Game/effect/eff05.h"
 #include "sf33rd/Source/Game/effect/effect.h"
 #include "sf33rd/Source/Game/engine/charset.h"
@@ -110,6 +111,14 @@ s32 effect_06_init() {
 
     if (lp_cnt == 0) {
         return 0;
+    }
+
+    if (Config_GetBool(CFG_DRAW_PLAYERS_ABOVE_HUD)) {
+        switch (bg_w.bg_index) {
+        case 16:         // Makoto's stage
+            lp_cnt -= 1; // Remove large tree on the right
+            break;
+        }
     }
 
     data_ptr = scr_obj_data6[bg_w.bg_index];

--- a/src/sf33rd/Source/Game/effect/eff85.c
+++ b/src/sf33rd/Source/Game/effect/eff85.c
@@ -1,6 +1,6 @@
 /**
  * @file eff85.c
- * TODO: identify what this effect does
+ * Bird on Chun-Li's stage
  */
 
 #include "sf33rd/Source/Game/effect/eff85.h"

--- a/src/sf33rd/Source/Game/effect/eff94.c
+++ b/src/sf33rd/Source/Game/effect/eff94.c
@@ -1,6 +1,6 @@
 /**
  * @file eff94.c
- * TODO: identify what this effect does
+ * Objects reacting to knockdowns, like plate's on Chun-Li's stage
  */
 
 #include "sf33rd/Source/Game/effect/eff94.h"

--- a/src/sf33rd/Source/Game/effect/effi4.c
+++ b/src/sf33rd/Source/Game/effect/effi4.c
@@ -1,6 +1,6 @@
 /**
  * @file effi4.c
- * TODO: identify what this effect does
+ * Bamboo tree on Chun-Li's stage
  */
 
 #include "sf33rd/Source/Game/effect/effi4.h"

--- a/src/sf33rd/Source/Game/stage/bg150.c
+++ b/src/sf33rd/Source/Game/stage/bg150.c
@@ -5,6 +5,7 @@
 
 #include "sf33rd/Source/Game/stage/bg150.h"
 #include "common.h"
+#include "port/config/config.h"
 #include "sf33rd/Source/Game/effect/eff05.h"
 #include "sf33rd/Source/Game/effect/eff06.h"
 #include "sf33rd/Source/Game/effect/eff12.h"
@@ -54,15 +55,19 @@ void bg1502_init00() {
     bgw_ptr->old_pos_x = bgw_ptr->xy[0].disp.pos = bgw_ptr->pos_x_work = 0x200;
     bgw_ptr->hos_xy[0].cal = bgw_ptr->wxy[0].cal = bgw_ptr->xy[0].cal;
     bgw_ptr->zuubun = 0;
+
     effect_05_init();
     effect_12_init(5);
     effect_06_init();
-    effect_44_init(8);
+    effect_44_init(8); // Men eating at the cafe
     effect_25_init(0);
-    effect_94_init(0);
-    effect_94_init(1);
-    effect_I4_init();
-    effect_85_init();
+    effect_94_init(0); // Stationary plates
+    effect_94_init(1); // Single plate that can fall
+    effect_85_init();  // Bird
+
+    if (!Config_GetBool(CFG_DRAW_PLAYERS_ABOVE_HUD)) {
+        effect_I4_init(); // Bamboo
+    }
 }
 
 void bg1502_sync_common() {

--- a/src/sf33rd/Source/Game/system/sys_sub.c
+++ b/src/sf33rd/Source/Game/system/sys_sub.c
@@ -6,6 +6,7 @@
 #include "sf33rd/Source/Game/system/sys_sub.h"
 #include "common.h"
 #include "main.h"
+#include "port/config/config.h"
 #include "sf33rd/AcrSDK/common/mlPAD.h"
 #include "sf33rd/Source/Game/com/com_data.h"
 #include "sf33rd/Source/Game/com/com_datu.h"
@@ -888,28 +889,30 @@ bool Check_PL_Load() {
     return Check_LDREQ_Queue_Player(0) && Check_LDREQ_Queue_Player(1);
 }
 
-void BG_Draw_System() {
-    u8 i;
-    u16 mask = 1 & 0xFFFF;
-    u16 s2;
-    u16 s3;
+static bool bg_layer_disabled(int i) {
+    if (!Config_GetBool(CFG_DRAW_PLAYERS_ABOVE_HUD)) {
+        return false;
+    }
 
-    if (bg_disp_off == 0) {
-        for (i = 0; i < 4; i++, s2 = mask *= 2) {
-            if (Screen_Switch_Buffer & mask) {
-                scr_trans(i);
-            }
-        }
-    } else {
-        for (i = 0; i < 4; i++, s3 = mask *= 2) {
-            if (Screen_Switch_Buffer & mask) {
-                scr_calc(i);
-            }
+    // Rain on Yang's stage
+    if ((bg_w.bg_index == 10) && (i == 1)) {
+        return true;
+    }
+
+    return false;
+}
+
+void BG_Draw_System() {
+    for (int i = 0; i < 4; i++) {
+        if ((bg_disp_off == 0) && (Screen_Switch_Buffer & (1 << i)) && !bg_layer_disabled(i)) {
+            scr_trans(i);
+        } else {
+            scr_calc(i);
         }
     }
 
     if (Play_Game == 0) {
-        for (i = 0; i < 4; i++) {
+        for (int i = 0; i < 4; i++) {
             if (Unsubstantial_BG[i]) {
                 scr_calc(i);
             }


### PR DESCRIPTION
Before vs after

Chun-Li
<img width="1072" height="864" alt="chun before" src="https://github.com/user-attachments/assets/e7a0c6ce-12eb-4831-bcfb-ed35741d1e86" />
<img width="1072" height="864" alt="chun after" src="https://github.com/user-attachments/assets/d8b403f2-f083-4b3d-9d67-e6aa26c8a789" />

Makoto
<img width="1072" height="864" alt="makoto before" src="https://github.com/user-attachments/assets/a1df7321-e1f5-41af-81b3-d0484da64e68" />
<img width="1072" height="864" alt="makoto after" src="https://github.com/user-attachments/assets/66dd019e-d601-40b1-978b-772d0d85b218" />

Yang
<img width="1072" height="864" alt="yang before" src="https://github.com/user-attachments/assets/8e0c7711-8b2a-472a-8d87-9f4b2211b985" />
<img width="1072" height="864" alt="yang after" src="https://github.com/user-attachments/assets/5ef457f4-8f52-4b98-8f8d-9d4b9bc4635d" />
