### PR TITLE
Added Basic String Rendering Functionality

### DIFF
--- a/src/sf33rd/Source/Game/ui/glyph_renderer.c
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.c
@@ -4,17 +4,13 @@
 #include "sf33rd/Source/Game/ui/glyph_renderer.h"
 
 #include <SDL3/SDL.h>
-#include <ctype.h>
-#include <string.h>
-#include <wctype.h>
-
 #define GLYPH_COLOR_STRIDE 4
 
 static Uint32 glyph_texture = 0;
-static Uint32 stringKerning = 8;
+static const Uint32 string_kerning = 8;
 
 // hacky way to quickly map the punctuation to sprite atlas positions
-static char* puncMap = ".,!:()><";
+static char* punc_map = ".,!:()><";
 static GlyphPosition puncPositions[10] = { (GlyphPosition) { 26, 1 }, (GlyphPosition) { 27, 1 },
                                            (GlyphPosition) { 33, 0 }, (GlyphPosition) { 30, 0 },
                                            (GlyphPosition) { 26, 0 }, (GlyphPosition) { 27, 0 },
@@ -64,53 +60,31 @@ void GlyphRenderer_DrawDigit(Uint8 digit, GlyphPosition screen_pos, GlyphColor c
     GlyphRenderer_DrawGlyph((GlyphPosition) { digit, 2 }, screen_pos, color, z);
 }
 
-/**
- * Used to get the index of the character in the string. Limited error checking due to this only being called if it is
- * in the string.
- */
-int indexOf(const char* str, const char f) {
-    int i = 0;
-
-    while (str[i] != '\0') {
-        if (str[i] == f)
-            return i;
-        i++;
-    }
-    return 0;
-}
-
 void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, float z) {
-    if (isalpha(c)) {
-
-        if (isupper(c)) {
-            int pos = c - 'A';
+    if (SDL_isalpha(c)) {
+        if (SDL_isupper(c)) {
+            const int pos = c - 'A';
             GlyphRenderer_DrawGlyph((GlyphPosition) { pos, 0 }, screen_pos, color, z);
-        } else if (islower(c)) {
+        } else if (SDL_islower(c)) {
             int pos = c - 'a';
             GlyphRenderer_DrawGlyph((GlyphPosition) { pos, 1 }, screen_pos, color, z);
         }
-
-    } else if (isspace(c) || c == '_') {
-        // draw nothing if the character is a space
-        // (also currently maps underscores because the glyph sheet doesn't have them)
-        GlyphRenderer_DrawGlyph((GlyphPosition) { 10, 2 }, screen_pos, color, z);
-
-    } else if (isdigit(c)) {
-        // render numbers using the other function
+    } else if (SDL_isdigit(c)) {
         GlyphRenderer_DrawDigit((int)(c - '0'), screen_pos, color, z);
-    } else if (strchr(puncMap, c)) {
-        // if the string is in the mapped list of punctuation, find the matching sprite atlas
-        GlyphPosition puncPos = puncPositions[indexOf(puncMap, c)];
+    } else if (strchr(punc_map, c)) {
+        GlyphPosition puncPos = puncPositions[(int)(strchr(punc_map, c) - punc_map)];
         GlyphRenderer_DrawGlyph(puncPos, screen_pos, color, z);
+    } else if (SDL_isspace(c) || c == '_') {
+        return;
     } else {
         // draw an X if the character doesn't exist in the spritesheet
         GlyphRenderer_DrawGlyph((GlyphPosition) { 23, 0 }, screen_pos, GLYPH_COLOR_HEAVY, z);
     }
 }
 
-void GlyphRenderer_DrawString(char* str, GlyphPosition screen_pos, GlyphColor color, float z) {
-    for (int i = 0; i < strlen(str); i++) {
-        screen_pos.x += stringKerning;
-        GlyphRenderer_DrawChar(str[i], screen_pos, color, z);
+void GlyphRenderer_DrawString(GlyphPosition screen_pos, GlyphColor color, float z, const char* format, ...) {
+    for (int i = 0; i < strlen(format); i++) {
+        GlyphRenderer_DrawChar(format[i], screen_pos, color, z);
+        screen_pos.x += string_kerning;
     }
 }

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.c
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.c
@@ -94,6 +94,10 @@ void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, 
         // draw nothing if the character is a space
         // (also currently maps underscores because the glyph sheet doesn't have them)
         GlyphRenderer_DrawGlyph((GlyphPosition) { 10, 2 }, screen_pos, color, z);
+
+    } else if (isdigit(c)) {
+        // render numbers using the other function
+        GlyphRenderer_DrawDigit((int)(c - '0'), screen_pos, color, z);
     } else if (strchr(puncMap, c)) {
         // if the string is in the mapped list of punctuation, find the matching sprite atlas
         GlyphPosition puncPos = puncPositions[indexOf(puncMap, c)];

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.c
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.c
@@ -14,10 +14,11 @@ static Uint32 glyph_texture = 0;
 static Uint32 stringKerning = 8;
 
 // hacky way to quickly map the punctuation to sprite atlas positions
-static char* puncMap = ".,!:()";
-static GlyphPosition puncPositions[6] = { (GlyphPosition) { 26, 1 }, (GlyphPosition) { 27, 1 },
-                                          (GlyphPosition) { 33, 0 }, (GlyphPosition) { 30, 0 },
-                                          (GlyphPosition) { 26, 0 }, (GlyphPosition) { 27, 0 } };
+static char* puncMap = ".,!:()><";
+static GlyphPosition puncPositions[10] = { (GlyphPosition) { 26, 1 }, (GlyphPosition) { 27, 1 },
+                                           (GlyphPosition) { 33, 0 }, (GlyphPosition) { 30, 0 },
+                                           (GlyphPosition) { 26, 0 }, (GlyphPosition) { 27, 0 },
+                                           (GlyphPosition) { 28, 2 }, (GlyphPosition) { 30, 2 } };
 
 static FLTexture* get_texture() {
     return &flTexture[glyph_texture - 1];
@@ -89,8 +90,9 @@ void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, 
             GlyphRenderer_DrawGlyph((GlyphPosition) { pos, 1 }, screen_pos, color, z);
         }
 
-    } else if (isspace(c)) {
+    } else if (isspace(c) || c == '_') {
         // draw nothing if the character is a space
+        // (also currently maps underscores because the glyph sheet doesn't have them)
         GlyphRenderer_DrawGlyph((GlyphPosition) { 10, 2 }, screen_pos, color, z);
     } else if (strchr(puncMap, c)) {
         // if the string is in the mapped list of punctuation, find the matching sprite atlas

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.c
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.c
@@ -1,9 +1,11 @@
-#include "sf33rd/Source/Game/ui/glyph_renderer.h"
 #include "core/renderer.h"
 #include "sf33rd/AcrSDK/ps2/flps2etc.h"
 #include "sf33rd/AcrSDK/ps2/foundaps2.h"
+#include "sf33rd/Source/Game/ui/glyph_renderer.h"
 
 #include <SDL3/SDL.h>
+#include <ctype.h>
+#include <wctype.h>
 
 #define GLYPH_COLOR_STRIDE 4
 
@@ -52,3 +54,22 @@ void GlyphRenderer_DrawDigit(Uint8 digit, GlyphPosition screen_pos, GlyphColor c
 
     GlyphRenderer_DrawGlyph((GlyphPosition) { digit, 2 }, screen_pos, color, z);
 }
+
+void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, float z) {
+    if (isalpha(c)) {
+
+        if (isupper(c)) {
+            int pos = c - 'A';
+            GlyphRenderer_DrawGlyph((GlyphPosition) { pos, 0 }, screen_pos, color, z);
+        } else if (islower(c)) {
+            int pos = c - 'a';
+            GlyphRenderer_DrawGlyph((GlyphPosition) { pos, 1 }, screen_pos, color, z);
+        }
+
+    } else {
+        // draw an X if the character doesn't exist in the spritesheet
+        GlyphRenderer_DrawGlyph((GlyphPosition) { 23, 0 }, screen_pos, GLYPH_COLOR_HEAVY, z);
+    }
+}
+
+void GlyphRenderer_DrawString(char c, GlyphPosition screen_pos, GlyphColor color, float z);

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.c
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.c
@@ -10,7 +10,7 @@
 #define GLYPH_COLOR_STRIDE 4
 
 static Uint32 glyph_texture = 0;
-
+static Uint32 stringKerning = 8;
 static FLTexture* get_texture() {
     return &flTexture[glyph_texture - 1];
 }
@@ -66,10 +66,17 @@ void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, 
             GlyphRenderer_DrawGlyph((GlyphPosition) { pos, 1 }, screen_pos, color, z);
         }
 
+    } else if (isspace(c)) {
+        GlyphRenderer_DrawGlyph((GlyphPosition) { 10, 2 }, screen_pos, color, z);
     } else {
         // draw an X if the character doesn't exist in the spritesheet
         GlyphRenderer_DrawGlyph((GlyphPosition) { 23, 0 }, screen_pos, GLYPH_COLOR_HEAVY, z);
     }
 }
 
-void GlyphRenderer_DrawString(char c, GlyphPosition screen_pos, GlyphColor color, float z);
+void GlyphRenderer_DrawString(char* str, GlyphPosition screen_pos, GlyphColor color, float z) {
+    for (int i = 0; i < strlen(str); i++) {
+        screen_pos.x += stringKerning;
+        GlyphRenderer_DrawChar(str[i], screen_pos, color, z);
+    }
+}

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.c
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.c
@@ -5,12 +5,20 @@
 
 #include <SDL3/SDL.h>
 #include <ctype.h>
+#include <string.h>
 #include <wctype.h>
 
 #define GLYPH_COLOR_STRIDE 4
 
 static Uint32 glyph_texture = 0;
 static Uint32 stringKerning = 8;
+
+// hacky way to quickly map the punctuation to sprite atlas positions
+static char* puncMap = ".,!:()";
+static GlyphPosition puncPositions[6] = { (GlyphPosition) { 26, 1 }, (GlyphPosition) { 27, 1 },
+                                          (GlyphPosition) { 33, 0 }, (GlyphPosition) { 30, 0 },
+                                          (GlyphPosition) { 26, 0 }, (GlyphPosition) { 27, 0 } };
+
 static FLTexture* get_texture() {
     return &flTexture[glyph_texture - 1];
 }
@@ -55,6 +63,21 @@ void GlyphRenderer_DrawDigit(Uint8 digit, GlyphPosition screen_pos, GlyphColor c
     GlyphRenderer_DrawGlyph((GlyphPosition) { digit, 2 }, screen_pos, color, z);
 }
 
+/**
+ * Used to get the index of the character in the string. Limited error checking due to this only being called if it is
+ * in the string.
+ */
+int indexOf(const char* str, const char f) {
+    int i = 0;
+
+    while (str[i] != '\0') {
+        if (str[i] == f)
+            return i;
+        i++;
+    }
+    return 0;
+}
+
 void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, float z) {
     if (isalpha(c)) {
 
@@ -67,7 +90,12 @@ void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, 
         }
 
     } else if (isspace(c)) {
+        // draw nothing if the character is a space
         GlyphRenderer_DrawGlyph((GlyphPosition) { 10, 2 }, screen_pos, color, z);
+    } else if (strchr(puncMap, c)) {
+        // if the string is in the mapped list of punctuation, find the matching sprite atlas
+        GlyphPosition puncPos = puncPositions[indexOf(puncMap, c)];
+        GlyphRenderer_DrawGlyph(puncPos, screen_pos, color, z);
     } else {
         // draw an X if the character doesn't exist in the spritesheet
         GlyphRenderer_DrawGlyph((GlyphPosition) { 23, 0 }, screen_pos, GLYPH_COLOR_HEAVY, z);

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.h
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.h
@@ -31,7 +31,6 @@ typedef enum GlyphColor {
 bool GlyphRenderer_Init();
 void GlyphRenderer_DrawGlyph(GlyphPosition atlas_pos, GlyphPosition screen_pos, GlyphColor color, float z);
 void GlyphRenderer_DrawDigit(Uint8 digit, GlyphPosition screen_pos, GlyphColor color, float z);
-int indexOf(const char* str, const char f);
 void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, float z);
-void GlyphRenderer_DrawString(char* str, GlyphPosition screen_pos, GlyphColor color, float z);
+void GlyphRenderer_DrawString(GlyphPosition screen_pos, GlyphColor color, float z, const char* format, ...);
 #endif

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.h
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.h
@@ -32,5 +32,5 @@ bool GlyphRenderer_Init();
 void GlyphRenderer_DrawGlyph(GlyphPosition atlas_pos, GlyphPosition screen_pos, GlyphColor color, float z);
 void GlyphRenderer_DrawDigit(Uint8 digit, GlyphPosition screen_pos, GlyphColor color, float z);
 void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, float z);
-void GlyphRenderer_DrawString(char c, GlyphPosition screen_pos, GlyphColor color, float z);
+void GlyphRenderer_DrawString(char* str, GlyphPosition screen_pos, GlyphColor color, float z);
 #endif

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.h
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.h
@@ -31,6 +31,7 @@ typedef enum GlyphColor {
 bool GlyphRenderer_Init();
 void GlyphRenderer_DrawGlyph(GlyphPosition atlas_pos, GlyphPosition screen_pos, GlyphColor color, float z);
 void GlyphRenderer_DrawDigit(Uint8 digit, GlyphPosition screen_pos, GlyphColor color, float z);
+int indexOf(const char* str, const char f);
 void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, float z);
 void GlyphRenderer_DrawString(char* str, GlyphPosition screen_pos, GlyphColor color, float z);
 #endif

--- a/src/sf33rd/Source/Game/ui/glyph_renderer.h
+++ b/src/sf33rd/Source/Game/ui/glyph_renderer.h
@@ -31,5 +31,6 @@ typedef enum GlyphColor {
 bool GlyphRenderer_Init();
 void GlyphRenderer_DrawGlyph(GlyphPosition atlas_pos, GlyphPosition screen_pos, GlyphColor color, float z);
 void GlyphRenderer_DrawDigit(Uint8 digit, GlyphPosition screen_pos, GlyphColor color, float z);
-
+void GlyphRenderer_DrawChar(char c, GlyphPosition screen_pos, GlyphColor color, float z);
+void GlyphRenderer_DrawString(char c, GlyphPosition screen_pos, GlyphColor color, float z);
 #endif


### PR DESCRIPTION
Adds in functions to the glyphrenderer that allows for basic strings to be rendered in the same way numbers and glyphs can be right now. Currently only supports:
- Uppercase.
- Lowercase.
- Spaces.
- Numbers.
- Underscores (converted into spaces).
- Punctuation `.,!:()`.
- `<` and `>` (converted into the arrows used for directional inputs, since I wanted a way to display those arrows easily).

All other glyphs render a red X.

Most of these limitations come from the spritesheet in `assets/` only having so many characters right now, but it could be expanded in the future if need be. 